### PR TITLE
ci: enforce conventional commits in PR titles

### DIFF
--- a/.github/workflows/lint_pr_title.yaml
+++ b/.github/workflows/lint_pr_title.yaml
@@ -1,0 +1,21 @@
+# https://github.com/amannn/action-semantic-pull-request
+name: "Lint PR against Conventional Commits"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Uses https://github.com/amannn/action-semantic-pull-request.

We will also need to change the default settings to encourage squashes. See
https://github.blog/changelog/2022-05-11-default-to-pr-titles-for-squash-merge-commit-messages/ https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/configuring-commit-squashing-for-pull-requests

I typically keep merge commits when the associated commits follow conventional commits. We could prefix with `chore:`

closes #5