### PR TITLE
feat: add KEEP_FOR_RE() macro to SKSE/Impl/PCH.h

### DIFF
--- a/CommonLibSF/.gitignore
+++ b/CommonLibSF/.gitignore
@@ -1,0 +1,13 @@
+/[Bb]uild
+CMakeUserPresets.json
+CMakeFiles
+CMakeCache.txt
+*.cmake
+/out*
+/.vs*
+/.vscode*
+/.idea
+conan.lock
+conanbuildinfo.*
+conaninfo.txt
+graph_info.json

--- a/CommonLibSF/include/SFSE/Impl/PCH.h
+++ b/CommonLibSF/include/SFSE/Impl/PCH.h
@@ -762,4 +762,12 @@ namespace REL
 #include "RE/Offsets_RTTI.h"
 #include "RE/Offsets_VTABLE.h"
 
+#ifdef _DEBUG
+// Generates a concrete function to force the class to be included in the PDB when loading types from PDB for IDA/Ghidra
+#define KEEP_FOR_RE() void KeepForRE(){};
+#else
+// Generates a concrete function to help with RE, does nothing on release builds
+#define KEEP_FOR_RE()
+#endif
+
 #undef cdecl // Workaround for Clang.


### PR DESCRIPTION
**Problem**: 
- Non-concrete classes are optimized out of the pdb when building the library

**Proposed solution**:
- Add the provided `KEEP_FOR_RE()` macro to each reversed class (possibly via a GitHub action) to concretize it and prevent it from being optimized out during debug builds 