### PR TITLE
fix!: remove `/FI` (#22) and revert some changes in #19

### DIFF
--- a/CommonLibSF/CMakeLists.txt
+++ b/CommonLibSF/CMakeLists.txt
@@ -99,7 +99,6 @@ if (MSVC)
 			/wd5053 # support for 'explicit(<expr>)' in C++17 and earlier is a vendor extension
 			/wd5204 # 'type-name': class has virtual functions, but its trivial destructor is not virtual; instances of objects derived from this class may not be destructed correctly
 			/wd5220 # 'member': a non-static data member with a volatile qualified type no longer implies that compiler generated copy / move constructors and copy / move assignment operators are not trivial
-			/FI${CMAKE_CURRENT_SOURCE_DIR}/include/SFSE/Impl/PCH.h
 	)
 endif()
 

--- a/CommonLibSF/CMakePresets.json
+++ b/CommonLibSF/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 6,
   "cmakeMinimumRequired": {
     "major": 3,
     "minor": 26,

--- a/CommonLibSF/CMakePresets.json
+++ b/CommonLibSF/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-  "version": 6,
+  "version": 3,
   "cmakeMinimumRequired": {
     "major": 3,
     "minor": 26,
@@ -10,7 +10,6 @@
       "name": "common",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL",
         "CMAKE_CXX_FLAGS": "$env{PROJECT_PLATFORM_FLAGS} $env{PROJECT_TEXT_FLAGS} $env{PROJECT_COMPILER_FLAGS} $penv{CXXFLAGS}"
       },
       "vendor": {
@@ -25,46 +24,34 @@
       "name": "packaging-vcpkg",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "CMAKE_TOOLCHAIN_FILE": {
+          "type": "STRING",
+          "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+        },
         "VCPKG_TARGET_TRIPLET": "x64-windows-static-md"
       }
     },
     {
-      "name": "buildtype-debug-clang",
+      "name": "buildtype-debug",
       "hidden": true,
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
-      "name": "buildtype-release-clang",
+      "name": "buildtype-release",
       "hidden": true,
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
       }
     },
     {
-      "name": "buildtype-debug-msvc",
-      "hidden": true,
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_CXX_FLAGS_DEBUG": "/Od /MDd",
-        "CMAKE_SHARED_LINKER_FLAGS_DEBUG": "/DEBUG:FULL /LTCG:INCREMENTAL /DEBUGTYPE:FIXUP"
-      }
-    },
-    {
-      "name": "buildtype-release-msvc",
-      "hidden": true,
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_CXX_FLAGS_RELEASE": "/fp:fast /GL /GR- /Gw /O2 /Ob3 /Qpar",
-        "CMAKE_SHARED_LINKER_FLAGS_RELEASE": "/OPT:REF,ICF=4"
-      }
-    },
-    {
       "name": "x64",
       "hidden": true,
-      "architecture": "x64"
+      "architecture": "x64",
+      "cacheVariables": {
+        "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
+      }
     },
     {
       "name": "generator-msvc",
@@ -81,9 +68,8 @@
       "name": "compiler-msvc",
       "hidden": true,
       "environment": {
-        "PROJECT_COMPILER": "msvc",
-        "PROJECT_COMPILER_FLAGS": "/cgthreads8 /diagnostics:caret /EHsc /fp:contract /fp:except- /guard:cf- /MP /permissive- /sdl /W4 /Zc:__cplusplus /Zc:enumTypes /Zc:lambda /Zc:preprocessor /Zc:referenceBinding /Zc:rvalueCast /Zc:templateScope /Zc:ternary /bigobj",
-        "CMAKE_SHARED_LINKER_FLAGS": "/CGTHREADS:8 /MACHINE:x64 /LTCG:INCREMENTAL"
+        "PROJECT_COMPILER_FLAGS": "/cgthreads8 /diagnostics:caret /fp:contract /fp:except- /guard:cf- /permissive- /Zc:__cplusplus /Zc:enumTypes /Zc:lambda /Zc:preprocessor /Zc:referenceBinding /Zc:rvalueCast /Zc:templateScope /Zc:ternary /Zc:preprocessor /EHsc /MP /W4 /WX /external:anglebrackets /external:W0",
+        "PROJECT_COMPILER": "msvc"
       }
     },
     {
@@ -122,7 +108,7 @@
       "inherits": [
         "common",
         "packaging-vcpkg",
-        "buildtype-debug-msvc",
+        "buildtype-debug",
         "generator-msvc",
         "compiler-msvc"
       ]
@@ -132,9 +118,20 @@
       "inherits": [
         "common",
         "packaging-vcpkg",
-        "buildtype-debug-msvc",
+        "buildtype-debug",
         "generator-ninja",
         "compiler-msvc"
+      ]
+    },
+    {
+      "name": "build-debug-clang-cl-msvc",
+      "toolset": "ClangCL",
+      "inherits": [
+        "common",
+        "packaging-vcpkg",
+        "buildtype-debug",
+        "generator-msvc",
+        "compiler-clang-cl"
       ]
     },
     {
@@ -142,8 +139,8 @@
       "inherits": [
         "common",
         "packaging-vcpkg",
-        "buildtype-debug-clang",
-        "generator-msvc",
+        "buildtype-debug",
+        "generator-ninja",
         "compiler-clang-cl"
       ]
     },
@@ -152,7 +149,7 @@
       "inherits": [
         "common",
         "packaging-vcpkg",
-        "buildtype-release-msvc",
+        "buildtype-release",
         "generator-msvc",
         "compiler-msvc"
       ]
@@ -162,9 +159,20 @@
       "inherits": [
         "common",
         "packaging-vcpkg",
-        "buildtype-release-msvc",
+        "buildtype-release",
         "generator-ninja",
         "compiler-msvc"
+      ]
+    },
+    {
+      "name": "build-release-clang-cl-msvc",
+      "toolset": "ClangCL",
+      "inherits": [
+        "common",
+        "packaging-vcpkg",
+        "buildtype-release",
+        "generator-msvc",
+        "compiler-clang-cl"
       ]
     },
     {
@@ -172,7 +180,7 @@
       "inherits": [
         "common",
         "packaging-vcpkg",
-        "buildtype-release-clang",
+        "buildtype-release",
         "generator-ninja",
         "compiler-clang-cl"
       ]
@@ -200,14 +208,24 @@
       "displayName": "4. (Release) MSVC - MSVC"
     },
     {
-      "name": "debug-clang-cl",
+      "name": "debug-clang-cl-ninja",
       "configurePreset": "build-debug-clang-cl-ninja",
       "displayName": "5. (Debug) Clang - Ninja"
     },
     {
-      "name": "release-clang-cl",
+      "name": "release-clang-cl-ninja",
       "configurePreset": "build-release-clang-cl-ninja",
       "displayName": "6. (Release) Clang - Ninja"
+    },
+    {
+      "name": "debug-clang-cl-msvc",
+      "configurePreset": "build-debug-clang-cl-msvc",
+      "displayName": "7. (Debug) Clang - MSVC"
+    },
+    {
+      "name": "release-clang-cl-msvc",
+      "configurePreset": "build-release-clang-cl-msvc",
+      "displayName": "8. (Release) Clang - MSVC"
     }
   ]
 }

--- a/CommonLibSF/vcpkg.json
+++ b/CommonLibSF/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "commonlibsf",
-  "version-date": "2023-09-08",
+  "version-date": "2023-09-09",
   "port-version": 0,
   "description": "A collaborative reverse-engineered library for Starfield.",
   "homepage": "https://github.com/Starfield-Reverse-Engineering/CommonLibSF",

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@
 
 [See how to use CommonLibSF with vcpkg in your project.](https://github.com/Starfield-Reverse-Engineering/Starfield-RE-vcpkg)
 
+---
+
 #### git submodule
 
 `cd` into your project directory and run:
@@ -39,9 +41,11 @@ Then add the following to your `CMakeLists.txt`:
 
 ```cmake
 add_subdirectory(extern/CommonLibSF)
-target_link_libraries(${PROJECT_NAME}
-        PRIVATE
-        CommonLibSF::CommonLibSF)
+target_link_libraries(
+  ${PROJECT_NAME}
+  PRIVATE
+  CommonLibSF::CommonLibSF
+)
 ```
 
 ## End-User Dependencies

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![C++23](https://img.shields.io/static/v1?label=standard&message=c%2B%2B23&color=blue&logo=c%2B%2B&&logoColor=red&style=flat)](https://en.cppreference.com/w/cpp/compiler_support)
 ![Platform](https://img.shields.io/static/v1?label=platform&message=windows&color=dimgray&style=flat&logo=windows)
 [![Game version](https://img.shields.io/badge/game%20version-1.7.23-orange)](#Developing-with-CommonLibSF)
-[![VCPKG_VER](https://img.shields.io/static/v1?label=vcpkg%20registry&message=2023-09-08&color=green&style=flat)](https://github.com/Starfield-Reverse-Engineering/Starfield-RE-vcpkg)
+[![VCPKG_VER](https://img.shields.io/static/v1?label=vcpkg%20registry&message=2023-09-09&color=green&style=flat)](https://github.com/Starfield-Reverse-Engineering/Starfield-RE-vcpkg)
 [![Main CI](https://img.shields.io/github/actions/workflow/status/Starfield-Reverse-Engineering/CommonLibSF/main_ci.yml)](https://github.com/Starfield-Reverse-Engineering/CommonLibSF/actions/workflows/main_ci.yml)
 
 ## Build Dependencies

--- a/build-clang-cl.bat
+++ b/build-clang-cl.bat
@@ -1,4 +1,4 @@
 echo off
 rd /s /q "build"
-cmake -B "%cd%/build" -S "%cd%/CommonLibSF" --preset=build-release-clang-cl
+cmake -B "%cd%/build" -S "%cd%/CommonLibSF" --preset=build-release-clang-cl-ninja
 cmake --build "%cd%/build" --config Release

--- a/build-msvc.bat
+++ b/build-msvc.bat
@@ -1,4 +1,4 @@
 echo off
 rd /s /q "build"
-cmake -B "%cd%/build" -S "%cd%/CommonLibSF" --preset=build-release-msvc
+cmake -B "%cd%/build" -S "%cd%/CommonLibSF" --preset=build-release-msvc-ninja
 cmake --build "%cd%/build" --config Release

--- a/make-sln-clang-cl.bat
+++ b/make-sln-clang-cl.bat
@@ -1,3 +1,3 @@
 echo off
 rd /s /q "build"
-cmake -B "%cd%/build" -S "%cd%/CommonLibSF" --preset=solution-clang-cl
+cmake -B "%cd%/build" -S "%cd%/CommonLibSF" --preset=build-debug-clang-cl-msvc

--- a/make-sln-msvc.bat
+++ b/make-sln-msvc.bat
@@ -1,3 +1,3 @@
 echo off
 rd /s /q "build"
-cmake -B "%cd%/build" -S "%cd%/CommonLibSF" --preset=solution-msvc
+cmake -B "%cd%/build" -S "%cd%/CommonLibSF" --preset=build-debug-msvc-msvc


### PR DESCRIPTION
1. Removed `/FI` force include directive flag to accommodate recent [vcpkg port update](https://github.com/Starfield-Reverse-Engineering/Starfield-RE-vcpkg/). This addresses the redefinition error when compiling project with a clean commonblisf vcpkg package.
2. Reverted some notable changes in #19 , see below.

---

Changes reverted:
In [CommonLibSF/CMakePresets.json](https://github.com/Starfield-Reverse-Engineering/CommonLibSF/compare/main...gottyduke:CommonLibSF:main?expand=1#diff-6d621fcc34a299795af75ba4026fa929d2b8b506efda705e332cf7dd06e6904f):

```json
{
  "name": "buildtype-debug-msvc",
  "hidden": true,
  "cacheVariables": {
    "CMAKE_BUILD_TYPE": "Debug",
    "CMAKE_CXX_FLAGS_DEBUG": "/Od /MDd",
    "CMAKE_SHARED_LINKER_FLAGS_DEBUG": "/DEBUG:FULL /LTCG:INCREMENTAL /DEBUGTYPE:FIXUP"
  }
}
```
Specifying `/LTCG:INCREMENTAL` for a debug build with `/Od` doesn't make sense here, `/LTCG` would imply `/GL` and `/Od` disables all optimizations. The other reason is that `/LTCG` flag is **explicitly** turned off for debug build with 
```cmake
set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_DEBUG OFF)
```
Then the `/MDd` flag is also redundant, this has been specified with
```cmake
"CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
```
Othe occurrences of `/LTCG` and `/MDd`/`/MTd` has been removed for the same reason.
`/MACHINE:x64` has been removed for linker flag, this is unnecessary.

configurePresets and buildPresets have added the `<config>-clang-cl-msvc` variants, for generating a **visual studio** solution with ClangCL toolset.

---

Fixes added for #19 : 
Updated the batch files to reflect the above CMakePresets.json changes.

---

closes #22 