### PR TITLE
ci: update to incremental version-date when needed

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -39,10 +39,9 @@ jobs:
       - name: Check for Commit
         uses: EndBug/add-and-commit@v9
         with:
-          author_name: maintenance
+          committer_name: maintenance
+          committer_email: 41898282+github-actions[bot]@users.noreply.github.com
           message: "ci: maintenance `${{ steps.versioning.outputs.VCPKG_VERSION }}`"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v2
@@ -50,3 +49,4 @@ jobs:
           token: ${{ secrets.VCPKG_HELPER_TOKEN }}
           repository: ${{ github.repository_owner }}/Starfield-RE-vcpkg
           event-type: update-event
+          client-payload: '{"sha": "${{ github.sha }}", "vcpkg-version": "${{ steps.versioning.outputs.VCPKG_VERSION }}"}'

--- a/CommonLibSF/vcpkg.json
+++ b/CommonLibSF/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "commonlibsf",
-  "version-date": "2023-09-09",
+  "version-date": "2023-09-09.1",
   "port-version": 0,
   "description": "A collaborative reverse-engineered library for Starfield.",
   "homepage": "https://github.com/Starfield-Reverse-Engineering/CommonLibSF",

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![C++23](https://img.shields.io/static/v1?label=standard&message=c%2B%2B23&color=blue&logo=c%2B%2B&&logoColor=red&style=flat)](https://en.cppreference.com/w/cpp/compiler_support)
 ![Platform](https://img.shields.io/static/v1?label=platform&message=windows&color=dimgray&style=flat&logo=windows)
 [![Game version](https://img.shields.io/badge/game%20version-1.7.23-orange)](#Developing-with-CommonLibSF)
-[![VCPKG_VER](https://img.shields.io/static/v1?label=vcpkg%20registry&message=2023-09-09&color=green&style=flat)](https://github.com/Starfield-Reverse-Engineering/Starfield-RE-vcpkg)
+[![VCPKG_VER](https://img.shields.io/static/v1?label=vcpkg%20registry&message=2023-09-09.1&color=green&style=flat)](https://github.com/Starfield-Reverse-Engineering/Starfield-RE-vcpkg)
 [![Main CI](https://img.shields.io/github/actions/workflow/status/Starfield-Reverse-Engineering/CommonLibSF/main_ci.yml)](https://github.com/Starfield-Reverse-Engineering/CommonLibSF/actions/workflows/main_ci.yml)
 
 ## Build Dependencies


### PR DESCRIPTION
- Fix some actions warning
  - Use new syntax for $GITHUB_OUTPUT
- Pass sha & version to Starfield-RE-vcpkg repo
  - I know the Starfield-RE-vcpkg repo only use sha for now, but with this that version can instead be passed from here to keep them synced
- Fix ps version requirement (`Get-Date -AsUTC` was added in 7.1)
- Add proper co-author with bot
![image](https://github.com/Starfield-Reverse-Engineering/CommonLibSF/assets/964655/46212a0a-41f3-4b61-9289-4745703353cf)

I know that @gottyduke had some local stuff for this, please discard this PR if I did anything wrong. Wasn't 100% if we're supposed to use the incremental date-version on this PR as well.

fixes https://github.com/Starfield-Reverse-Engineering/Starfield-RE-vcpkg/issues/6