### PR TITLE
feat: complete 'TESObjectREFR` inheritance and related classes

### DIFF
--- a/CommonLibSF/include/RE/A/ActorValueOwner.h
+++ b/CommonLibSF/include/RE/A/ActorValueOwner.h
@@ -10,7 +10,9 @@ namespace RE
 	public:
 		SF_RTTI_VTABLE(ActorValueOwner);
 
-		// add
+		virtual ~ActorValueOwner();	
+
+	    // add
 		virtual float GetActorValue(const ActorValueInfo& a_info);
 		virtual float GetPermanentActorValue(const ActorValueInfo& a_info);
 		virtual float GetBaseActorValue(const ActorValueInfo& a_info);

--- a/CommonLibSF/include/RE/B/BSTEvent.h
+++ b/CommonLibSF/include/RE/B/BSTEvent.h
@@ -2,37 +2,45 @@
 
 namespace RE
 {
-	namespace detail
-	{
-		class SinkBase
-		{
-			virtual ~SinkBase() = 0;
-		};
-	}
-
-	enum class BSEventNotifyControl : std::int32_t
+	enum class BSEventNotifyControl : std::uint32_t
 	{
 		kContinue,
 		kStop
 	};
 	using EventResult = BSEventNotifyControl;
 
+	namespace BSTEventDetail
+	{
+		class SinkBase
+		{
+		public:
+			virtual ~SinkBase() = 0;
+		};
+
+		class SourceBase
+		{
+		public:
+			virtual ~SourceBase() = 0;
+		};
+	}
+
 	template <class>
 	class BSTEventSource;
 
-	// 08
-	template <typename Event>
-	class BSTEventSink : public detail::SinkBase
+	template <class Event>
+	class BSTEventSink : public BSTEventDetail::SinkBase
 	{
 	public:
-		virtual ~BSTEventSink(){};
-		virtual BSEventNotifyControl ProcessEvent(const Event& a_event, [[maybe_unused]] BSTEventSource<Event>* a_source) { return EventResult::kContinue; };  // pure
+		~BSTEventSink() override = default;  // 00
+
+		// add
+		virtual BSEventNotifyControl ProcessEvent(const Event& a_event, BSTEventSource<Event>* a_source) = 0;  // 01
 	};
 
-	template <typename T>
-	class BSTEventSource
+	template <class Event>
+	class BSTEventSource : public BSTEventDetail::SourceBase
 	{
 	public:
-		// Sinks go here
+		~BSTEventSource() override = default;  // 00
 	};
 }

--- a/CommonLibSF/include/RE/I/IAnimationGraphManagerHolder.h
+++ b/CommonLibSF/include/RE/I/IAnimationGraphManagerHolder.h
@@ -1,0 +1,36 @@
+#pragma once
+
+namespace RE
+{
+	class IAnimationGraphManagerHolder
+	{
+	public:
+		virtual ~IAnimationGraphManagerHolder();  // 00
+
+		// add
+		virtual void Unk_01();  // 01
+		virtual void Unk_02();  // 02
+		virtual void Unk_03();  // 03
+		virtual void Unk_04();  // 04
+		virtual void Unk_05();  // 05
+		virtual void Unk_06();  // 06
+		virtual void Unk_07();  // 07
+		virtual void Unk_08();  // 08
+		virtual void Unk_09();  // 09
+		virtual void Unk_0A();  // 0A
+		virtual void Unk_0B();  // 0B
+		virtual void Unk_0C();  // 0C
+		virtual void Unk_0D();  // 0D
+		virtual void Unk_0E();  // 0E
+		virtual void Unk_0F();  // 0F
+		virtual void Unk_10();  // 10
+		virtual void Unk_11();  // 11
+		virtual void Unk_12();  // 12
+		virtual void Unk_13();  // 13
+		virtual void Unk_14();  // 14
+		virtual void Unk_15();  // 15
+		virtual void Unk_16();  // 16
+		virtual void Unk_17();  // 17
+		virtual void Unk_18();  // 18
+	};
+}

--- a/CommonLibSF/include/RE/I/IMovementInterface.h
+++ b/CommonLibSF/include/RE/I/IMovementInterface.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace RE
+{
+	struct IMovementInterface
+	{
+	public:
+		virtual ~IMovementInterface();  // 00
+	};
+	static_assert(sizeof(IMovementInterface) == 0x8);
+}

--- a/CommonLibSF/include/RE/I/IPostAnimationChannelUpdateFunctor.h
+++ b/CommonLibSF/include/RE/I/IPostAnimationChannelUpdateFunctor.h
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace RE
+{
+	class IPostAnimationChannelUpdateFunctor
+	{
+	public:
+		SF_RTTI_VTABLE(IPostAnimationChannelUpdateFunctor);
+
+		virtual ~IPostAnimationChannelUpdateFunctor();  // 00
+
+		// add
+		virtual void DoPostAnimationChannelUpdate() = 0;  // 01
+	};
+	static_assert(sizeof(IPostAnimationChannelUpdateFunctor) == 0x8);
+}

--- a/CommonLibSF/include/RE/N/NiPoint3.h
+++ b/CommonLibSF/include/RE/N/NiPoint3.h
@@ -45,11 +45,11 @@ namespace RE
 	};
 	static_assert(sizeof(NiPoint3) == 0xC);
 
-	class alignas(0x10) NiPoint3Aligned :
+	class alignas(0x10) NiPoint3A :
 		public NiPoint3
 	{
 	public:
 		std::array<std::byte, 0x4> padding;  // 0xC
 	};
-	static_assert(sizeof(NiPoint3Aligned) == 0x10);
+	static_assert(sizeof(NiPoint3A) == 0x10);
 }

--- a/CommonLibSF/include/RE/T/TESHandleForm.h
+++ b/CommonLibSF/include/RE/T/TESHandleForm.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "RE/T/TESForm.h"
+
+namespace RE
+{
+	class TESHandleForm :
+		public TESForm
+	{
+	public:
+		SF_RTTI_VTABLE(TESHandleForm);
+
+		~TESHandleForm() override;  // 00
+	};
+	static_assert(sizeof(TESHandleForm) == 0x38);
+}

--- a/CommonLibSF/src/RE/I/IAnimationGraphManagerHolder.cpp
+++ b/CommonLibSF/src/RE/I/IAnimationGraphManagerHolder.cpp
@@ -1,0 +1,5 @@
+﻿#include "RE/I/IAnimationGraphManagerHolder.h"
+namespace RE
+{
+}
+

--- a/CommonLibSF/src/RE/I/IMovementInterface.cpp
+++ b/CommonLibSF/src/RE/I/IMovementInterface.cpp
@@ -1,0 +1,5 @@
+﻿#include "RE/I/IMovementInterface.h"
+namespace RE
+{
+}
+

--- a/CommonLibSF/src/RE/I/IPostAnimationChannelUpdateFunctor.cpp
+++ b/CommonLibSF/src/RE/I/IPostAnimationChannelUpdateFunctor.cpp
@@ -1,0 +1,5 @@
+﻿#include "RE/I/IPostAnimationChannelUpdateFunctor.h"
+namespace RE
+{
+}
+

--- a/CommonLibSF/src/RE/T/TESHandleForm.cpp
+++ b/CommonLibSF/src/RE/T/TESHandleForm.cpp
@@ -1,0 +1,5 @@
+﻿#include "RE/T/TESHandleForm.h"
+namespace RE
+{
+}
+

--- a/CommonLibSF/src/RE/T/TESObjectREFR.cpp
+++ b/CommonLibSF/src/RE/T/TESObjectREFR.cpp
@@ -1,1 +1,32 @@
 #include "RE/T/TESObjectREFR.h"
+
+namespace RE
+{
+	TESObjectREFR* TESObjectREFR::GetAttachedSpaceship()
+	{
+		using func_t = decltype(&TESObjectREFR::GetAttachedSpaceship);
+		REL::Relocation<func_t> func{ REL::Offset(0x02B3A8D4) };
+		return func(this);
+	}
+
+	bool TESObjectREFR::HasKeyword(BGSKeyword* a_keyword)
+	{
+		using func_t = decltype(&TESObjectREFR::HasKeyword);
+		REL::Relocation<func_t> func{ REL::Offset(0x0139EE28) };
+		return func(this, a_keyword);
+	}
+
+	bool TESObjectREFR::IsCrimeToActivate()
+	{
+		using func_t = decltype(&TESObjectREFR::IsCrimeToActivate);
+		REL::Relocation<func_t> func{ REL::Offset(0x01A0DCA0) };
+		return func(this);
+	}
+
+	bool TESObjectREFR::IsInSpace()
+	{
+		using func_t = decltype(&TESObjectREFR::IsInSpace);
+		REL::Relocation<func_t> func{ REL::Offset(0x01A0E208) };
+		return func(this);
+	}
+}


### PR DESCRIPTION
- Switched to using `BSTEvent` class definitions from CommonLib, this gets rid of the unreferenced parameter error
- Added some getters and couple of functions
- `IsInSpaceship` was incorrectly defined, it is now `GetAttachedSpaceship` (note the return parameter should be a `NiSmartPointer` which isn't included as of yet)