### PR TITLE
feat: add default logger

### DIFF
--- a/CommonLibSF/include/SFSE/API.h
+++ b/CommonLibSF/include/SFSE/API.h
@@ -9,7 +9,7 @@
 
 namespace SFSE
 {
-	void Init(const LoadInterface* a_intfc) noexcept;
+	void Init(const LoadInterface* a_intfc, bool a_log = true) noexcept;
 	void RegisterForAPIInitEvent(std::function<void()> a_fn);
 
 	PluginHandle GetPluginHandle() noexcept;

--- a/CommonLibSF/include/SFSE/Interfaces.h
+++ b/CommonLibSF/include/SFSE/Interfaces.h
@@ -134,6 +134,8 @@ namespace SFSE
 
 		constexpr void MinimumRequiredXSEVersion(REL::Version a_version) noexcept { xseMinimum = a_version.pack(); }
 
+		[[nodiscard]] static const PluginVersionData* GetSingleton() noexcept;
+
 		const std::uint32_t dataVersion{ kVersion };
 		std::uint32_t       pluginVersion = 0;
 		char                pluginName[256] = {};

--- a/CommonLibSF/include/SFSE/Logger.h
+++ b/CommonLibSF/include/SFSE/Logger.h
@@ -23,6 +23,7 @@ namespace SFSE::log
 	SFSE_MAKE_SOURCE_LOGGER(critical, critical);
 
 	[[nodiscard]] std::optional<std::filesystem::path> log_directory();
+	void init();
 }  // namespace SFSE::log
 
 #undef SFSE_MAKE_SOURCE_LOGGER

--- a/CommonLibSF/src/SFSE/API.cpp
+++ b/CommonLibSF/src/SFSE/API.cpp
@@ -47,7 +47,7 @@ namespace SFSE
 		}
 	}  // namespace detail
 
-	void Init(const LoadInterface* a_intfc, bool a_log = true) noexcept
+	void Init(const LoadInterface* a_intfc, bool a_log) noexcept
 	{
 		stl_assert(a_intfc, "interface is null"sv);
 

--- a/CommonLibSF/src/SFSE/API.cpp
+++ b/CommonLibSF/src/SFSE/API.cpp
@@ -47,9 +47,12 @@ namespace SFSE
 		}
 	}  // namespace detail
 
-	void Init(const LoadInterface* a_intfc) noexcept
+	void Init(const LoadInterface* a_intfc, bool a_log = true) noexcept
 	{
 		stl_assert(a_intfc, "interface is null"sv);
+
+		if (a_log)
+			log::init();
 
 		(void)REL::Module::get();
 

--- a/CommonLibSF/src/SFSE/Interfaces.cpp
+++ b/CommonLibSF/src/SFSE/Interfaces.cpp
@@ -2,10 +2,6 @@
 #include "SFSE/API.h"
 #include "SFSE/Logger.h"
 
-#include <Windows.h>
-
-EXTERN_C IMAGE_DOS_HEADER __ImageBase;
-
 namespace SFSE
 {
 	REL::Version QueryInterface::RuntimeVersion() const
@@ -70,5 +66,10 @@ namespace SFSE
 	{
 		assert(this);
 		return reinterpret_cast<const detail::SFSETrampolineInterface*>(this);
+	}
+
+	const PluginVersionData* PluginVersionData::GetSingleton() noexcept
+	{
+		return reinterpret_cast<const PluginVersionData*>(WinAPI::GetProcAddress(WinAPI::GetCurrentModule(), "SFSEPlugin_Version"));
 	}
 }  // namespace SFSE

--- a/CommonLibSF/src/SFSE/Logger.cpp
+++ b/CommonLibSF/src/SFSE/Logger.cpp
@@ -48,7 +48,7 @@ namespace SFSE
 			logger->flush_on(spdlog::level::info);
 #endif
 			spdlog::set_default_logger(std::move(logger));
-			spdlog::set_pattern("[%^%L%$] %v");
+			spdlog::set_pattern("[%T.%e] [%=5t] [%L] %v");
 		}
 	}  // namespace log
 }  // namespace SFSE

--- a/CommonLibSF/src/SFSE/Logger.cpp
+++ b/CommonLibSF/src/SFSE/Logger.cpp
@@ -1,6 +1,9 @@
 #include "SFSE/Logger.h"
 #include "SFSE/API.h"
 
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/msvc_sink.h>
+
 #include <ShlObj.h>
 
 namespace SFSE
@@ -20,6 +23,33 @@ namespace SFSE
 			std::filesystem::path path = knownPath.get();
 			path /= "My Games\\Starfield\\SFSE\\Logs";
 			return path;
+		}
+
+		void init()
+		{
+			auto path = log_directory();
+			if (!path)
+				return;
+			
+			const auto data = PluginVersionData::GetSingleton();
+			*path /= data->GetPluginName();
+			*path /= L".log";
+
+			std::vector<spdlog::sink_ptr> sinks{
+				std::make_shared<spdlog::sinks::basic_file_sink_mt>(path->string(), true), 
+				std::make_shared<spdlog::sinks::msvc_sink_mt>()
+			};
+
+			auto logger = std::make_shared<spdlog::logger>("global", sinks.begin(), sinks.end());
+#ifndef NDEBUG
+			logger->set_level(spdlog::level::debug);
+			logger->flush_on(spdlog::level::debug);
+#else
+			logger->set_level(spdlog::level::info);
+			logger->flush_on(spdlog::level::info);
+#endif
+			spdlog::set_default_logger(std::move(logger));
+			spdlog::set_pattern("[%^%L%$] %v");
 		}
 	}  // namespace log
 }  // namespace SFSE

--- a/CommonLibSF/src/SFSE/Logger.cpp
+++ b/CommonLibSF/src/SFSE/Logger.cpp
@@ -32,8 +32,7 @@ namespace SFSE
 				return;
 			
 			const auto data = PluginVersionData::GetSingleton();
-			*path /= data->GetPluginName();
-			*path /= L".log";
+			*path /= std::format("{}.log", data->GetPluginName());
 
 			std::vector<spdlog::sink_ptr> sinks{
 				std::make_shared<spdlog::sinks::basic_file_sink_mt>(path->string(), true), 


### PR DESCRIPTION
When `SFSE::Init` is used, it will now initialize a default spdlog logger.
```cpp
SFSE::Init(a_sfse); // default log file will be automatically created
```

This behavior can be turned off by passing false as the optional second argument:
```cpp
SFSE::Init(a_sfse, false); // default log file is disabled
```
...if you have no need for a log file at all. Keep in mind that this sets the default logger for the module (plugin), you can still modify it's behavior through the spdlog api, such as setting the level, or the pattern.

Some keen eyed may notice that I am also registering an msvc sink, this will not impact performance as spdlog as of a somewhat recent version now checks if a debugger is attached, and if not, the sink is essentially a no-op, with no real cost to performance.

You can test this pr with the xmake template by specifying the `dev/qdx/logging` branch.