### PR TITLE
fix: add dbghelp.lib to cmake + typo

### DIFF
--- a/CommonLibSF/CMakeLists.txt
+++ b/CommonLibSF/CMakeLists.txt
@@ -116,6 +116,7 @@ target_link_libraries(
 	PUBLIC
 		spdlog::spdlog
 		Version.lib
+		Dbghelp.lib
 )
 
 if (SFSE_SUPPORT_XBYAK)

--- a/CommonLibSF/include/SFSE/Impl/WinAPI.h
+++ b/CommonLibSF/include/SFSE/Impl/WinAPI.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifdef _INC_WINAPIFAMILY
-#	error Windows API detected. Please move any Windows API includes after CommonLibF4, or remove them.
+#	error Windows API detected. Please move any Windows API includes after CommonLibSF, or remove them.
 #else
 
 namespace SFSE::WinAPI


### PR DESCRIPTION
Should fix the unresolved external symbol error for the `UnDecorateSymbolName` family of functions