### PR TITLE
fix: xbyak brings in <Windows.h>

### DIFF
--- a/CommonLibSF/src/SFSE/Trampoline.cpp
+++ b/CommonLibSF/src/SFSE/Trampoline.cpp
@@ -2,8 +2,14 @@
 
 #include "SFSE/Logger.h"
 
+// xbyak brings in <Windows.h>
 #ifdef SFSE_SUPPORT_XBYAK
-#	include <xbyak/xbyak.h>
+	#define NOMINMAX
+	#include <xbyak/xbyak.h>
+	#undef MEM_COMMIT
+	#undef MEM_FREE
+	#undef MEM_RESERVE
+	#undef PAGE_EXECUTE_READWRITE
 #endif
 
 namespace SFSE


### PR DESCRIPTION
Rather annoyingly xbyak brings in <Windows.h>. The impact is small as xbyak is only included in `Trampoline.cpp`. Consumers (plugins) should be fine as long as they include xbyak after CommonLibSF.