### PR TITLE
fix: use available format_string for now

### DIFF
--- a/CommonLibSF/include/SFSE/Impl/PCH.h
+++ b/CommonLibSF/include/SFSE/Impl/PCH.h
@@ -56,9 +56,6 @@
 static_assert(std::is_integral_v<std::time_t> && sizeof(std::time_t) == sizeof(std::size_t), "wrap std::time_t instead");
 
 #pragma warning(push)
-#ifndef SPDLOG_USE_STD_FORMAT
-#	define SPDLOG_USE_STD_FORMAT
-#endif
 #include <spdlog/spdlog.h>
 #pragma warning(pop)
 

--- a/CommonLibSF/include/SFSE/Logger.h
+++ b/CommonLibSF/include/SFSE/Logger.h
@@ -7,11 +7,11 @@
 	{                                                                                                                                                                                                                                                                                                                    \
 		a_func() = delete;                                                                                                                                                                                                                                                                                               \
                                                                                                                                                                                                                                                                                                                          \
-		explicit a_func(std::format_string<Args...> a_fmt, Args&&... a_args, std::source_location a_loc = std::source_location::current()) { spdlog::log(spdlog::source_loc{ a_loc.file_name(), static_cast<int>(a_loc.line()), a_loc.function_name() }, spdlog::level::a_type, a_fmt, std::forward<Args>(a_args)...); } \
+		explicit a_func(spdlog::format_string_t<Args...> a_fmt, Args&&... a_args, std::source_location a_loc = std::source_location::current()) { spdlog::log(spdlog::source_loc{ a_loc.file_name(), static_cast<int>(a_loc.line()), a_loc.function_name() }, spdlog::level::a_type, a_fmt, std::forward<Args>(a_args)...); } \
 	};                                                                                                                                                                                                                                                                                                                   \
                                                                                                                                                                                                                                                                                                                          \
 	template <class... Args>                                                                                                                                                                                                                                                                                             \
-	a_func(std::format_string<Args...>, Args&&...) -> a_func<Args...>;
+	a_func(spdlog::format_string_t<Args...>, Args&&...) -> a_func<Args...>;
 
 namespace SFSE::log
 {


### PR DESCRIPTION
`spdlog`'s vcpkg port doesn't build in c++20 or higher, so features like `std::format_string` aren't available. For now use `spdlog::format_string_t` to automatically pick an available format string.