### PR TITLE
feat: mark Relocation constructors as explicit

### DIFF
--- a/CommonLibSF/include/REL/ID.h
+++ b/CommonLibSF/include/REL/ID.h
@@ -75,7 +75,8 @@ namespace REL
 				requires(std::is_execution_policy_v<std::decay_t<ExecutionPolicy>>);
 
 			Offset2ID() :
-				Offset2ID(std::execution::sequenced_policy{}) {}
+				Offset2ID(std::execution::sequenced_policy{})
+			{}
 
 			[[nodiscard]] std::uint64_t operator()(std::size_t a_offset) const;
 
@@ -119,7 +120,10 @@ namespace REL
 				_stream.exceptions(std::ios::badbit | std::ios::failbit | std::ios::eofbit);
 			}
 
-			void ignore(std::streamsize a_count) { _stream.ignore(a_count); }
+			void ignore(std::streamsize a_count) 
+			{
+				_stream.ignore(a_count);
+			}
 
 			template <class T>
 			void readin(T& a_val)
@@ -145,13 +149,25 @@ namespace REL
 		public:
 			void read(istream_t& a_in);
 
-			[[nodiscard]] std::size_t address_count() const noexcept { return static_cast<std::size_t>(_addressCount); }
+			[[nodiscard]] std::size_t address_count() const noexcept
+			{
+				return static_cast<std::size_t>(_addressCount);
+			}
 
-			[[nodiscard]] std::uint64_t pointer_size() const noexcept { return static_cast<std::uint64_t>(_pointerSize); }
+			[[nodiscard]] std::uint64_t pointer_size() const noexcept
+			{
+				return static_cast<std::uint64_t>(_pointerSize);
+			}
 
-			[[nodiscard]] std::string_view name() const noexcept { return _name; }
+			[[nodiscard]] std::string_view name() const noexcept
+			{
+				return _name;
+			}
 
-			[[nodiscard]] Version version() const noexcept { return _version; }
+			[[nodiscard]] Version version() const noexcept
+			{
+				return _version;
+			}
 
 		private:
 			char          _name[20]{};
@@ -229,7 +245,8 @@ namespace REL
 		constexpr ID() noexcept = default;
 
 		explicit constexpr ID(std::uint64_t a_id) noexcept :
-			_id(a_id) {}
+			_id(a_id)
+		{}
 
 		constexpr ID& operator=(std::uint64_t a_id) noexcept
 		{
@@ -237,14 +254,26 @@ namespace REL
 			return *this;
 		}
 
-		[[nodiscard]] std::uintptr_t address() const { return base() + offset(); }
+		[[nodiscard]] std::uintptr_t address() const
+		{
+			return base() + offset();
+		}
 
-		[[nodiscard]] constexpr std::uint64_t id() const noexcept { return _id; }
+		[[nodiscard]] constexpr std::uint64_t id() const noexcept
+		{
+			return _id;
+		}
 
-		[[nodiscard]] std::size_t offset() const { return IDDatabase::get().id2offset(_id); }
+		[[nodiscard]] std::size_t offset() const
+		{
+			return IDDatabase::get().id2offset(_id);
+		}
 
 	private:
-		[[nodiscard]] static std::uintptr_t base() { return Module::get().base(); }
+		[[nodiscard]] static std::uintptr_t base()
+		{
+			return Module::get().base();
+		}
 
 		std::uint64_t _id{ 0 };
 	};

--- a/CommonLibSF/include/REL/Module.h
+++ b/CommonLibSF/include/REL/Module.h
@@ -4,7 +4,6 @@
 
 namespace REL
 {
-
 	class Segment
 	{
 	public:
@@ -24,15 +23,17 @@ namespace REL
 		Segment() noexcept = default;
 
 		Segment(std::uintptr_t a_proxyBase, std::uintptr_t a_address, std::uintptr_t a_size) noexcept :
-			_proxyBase(a_proxyBase), _address(a_address), _size(a_size) {}
+			_proxyBase(a_proxyBase), _address(a_address), _size(a_size)
+		{}
 
 		[[nodiscard]] std::uintptr_t address() const noexcept { return _address; }
-
 		[[nodiscard]] std::size_t offset() const noexcept { return address() - _proxyBase; }
-
 		[[nodiscard]] std::size_t size() const noexcept { return _size; }
 
-		[[nodiscard]] void* pointer() const noexcept { return std::bit_cast<void*>(address()); }
+		[[nodiscard]] void* pointer() const noexcept
+		{
+			return std::bit_cast<void*>(address());
+		}
 
 		template <class T>
 		[[nodiscard]] T* pointer() const noexcept

--- a/CommonLibSF/include/REL/Offset.h
+++ b/CommonLibSF/include/REL/Offset.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "REL/Module.h"
+
+namespace REL
+{
+	class Offset
+	{
+	public:
+		constexpr Offset() = default;
+
+		constexpr Offset(const std::ptrdiff_t a_offset) :
+			_offset(a_offset)
+        {}
+
+		[[nodiscard]] constexpr std::uintptr_t offset() const noexcept
+        {
+            return _offset;
+        }
+
+		[[nodiscard]] constexpr std::uintptr_t address() const noexcept
+        {
+            return Module::get().base() + _offset;
+        }
+
+	private:
+		std::ptrdiff_t _offset{ 0 };
+	};
+}

--- a/CommonLibSF/include/REL/Relocation.h
+++ b/CommonLibSF/include/REL/Relocation.h
@@ -203,20 +203,25 @@ namespace REL
 
 		constexpr Relocation() noexcept = default;
 
-		constexpr Relocation(const std::uintptr_t a_addr) noexcept :
-			_address(a_addr) {}
+		explicit constexpr Relocation(const std::uintptr_t a_addr) noexcept :
+			_address(a_addr)
+		{}
 
-		constexpr Relocation(Offset a_rva) noexcept :
-			_address(a_rva.address()) {}
+		explicit constexpr Relocation(const Offset a_rva) noexcept :
+			_address(a_rva.address())
+		{}
 
-		constexpr Relocation(Offset a_rva, std::ptrdiff_t a_offset) noexcept :
-			_address(a_rva.address() + a_offset) {}
+		explicit constexpr Relocation(const Offset a_rva, const std::ptrdiff_t a_offset) noexcept :
+			_address(a_rva.address() + a_offset)
+		{}
 
-		constexpr Relocation(ID a_id) noexcept :
-			_address(a_id.address()) {}
+		explicit constexpr Relocation(const ID a_id) noexcept :
+			_address(a_id.address())
+		{}
 
-		constexpr Relocation(ID a_id, std::ptrdiff_t a_offset) noexcept :
-			_address(a_id.address() + a_offset) {}
+		explicit constexpr Relocation(const ID a_id, const std::ptrdiff_t a_offset) noexcept :
+			_address(a_id.address() + a_offset)
+		{}
 
 		[[nodiscard]] constexpr value_type get() const  //
 			noexcept(std::is_nothrow_copy_constructible_v<value_type>)

--- a/CommonLibSF/include/REL/Relocation.h
+++ b/CommonLibSF/include/REL/Relocation.h
@@ -2,6 +2,7 @@
 
 #include "REL/ID.h"
 #include "REL/Module.h"
+#include "REL/Offset.h"
 #include "REL/Version.h"
 
 #define REL_MAKE_MEMBER_FUNCTION_POD_TYPE_HELPER_IMPL(a_nopropQual, a_propQual, ...)              \
@@ -192,22 +193,6 @@ namespace REL
 		}
 
 		assert(success != 0);
-	};
-
-	class Offset
-	{
-	public:
-		constexpr Offset() = default;
-
-		constexpr Offset(std::ptrdiff_t a_offset) :
-			_offset(a_offset) {}
-
-		[[nodiscard]] constexpr std::uintptr_t offset() const noexcept { return _offset; }
-
-		[[nodiscard]] constexpr std::uintptr_t address() const noexcept { return Module::get().base() + _offset; }
-
-	private:
-		std::ptrdiff_t _offset{ 0 };
 	};
 
 	template <typename T = std::uintptr_t>

--- a/CommonLibSF/include/REL/Version.h
+++ b/CommonLibSF/include/REL/Version.h
@@ -2,7 +2,6 @@
 
 namespace REL
 {
-
 	class Version
 	{
 	public:
@@ -42,14 +41,18 @@ namespace REL
 			return std::strong_ordering::equal;
 		}
 
-		[[nodiscard]] constexpr std::uint32_t pack() const noexcept { return static_cast<std::uint32_t>((_impl[0] & 0x0FF) << 24u | (_impl[1] & 0x0FF) << 16u | (_impl[2] & 0xFFF) << 4u | (_impl[3] & 0x00F) << 0u); }
+		[[nodiscard]] constexpr std::uint32_t pack() const noexcept
+		{
+			return static_cast<std::uint32_t>(
+				(_impl[0] & 0x0FF) << 24u |
+				(_impl[1] & 0x0FF) << 16u |
+				(_impl[2] & 0xFFF) << 4u |
+				(_impl[3] & 0x00F) << 0u);
+		}
 
 		[[nodiscard]] constexpr value_type major() const noexcept { return _impl[0]; }
-
 		[[nodiscard]] constexpr value_type minor() const noexcept { return _impl[1]; }
-
 		[[nodiscard]] constexpr value_type patch() const noexcept { return _impl[2]; }
-
 		[[nodiscard]] constexpr value_type build() const noexcept { return _impl[3]; }
 
 		[[nodiscard]] std::string string(std::string_view a_separator = "-"sv) const
@@ -74,15 +77,29 @@ namespace REL
 			return result;
 		}
 
-		[[nodiscard]] static constexpr Version unpack(std::uint32_t a_packedVersion) noexcept { return REL::Version{ static_cast<value_type>((a_packedVersion >> 24) & 0x0FF), static_cast<value_type>((a_packedVersion >> 16) & 0x0FF), static_cast<value_type>((a_packedVersion >> 4) & 0xFFF), static_cast<value_type>(a_packedVersion & 0x0F) }; }
+		[[nodiscard]] static constexpr Version unpack(std::uint32_t a_packedVersion) noexcept
+		{
+			return REL::Version{ 
+				static_cast<value_type>((a_packedVersion >> 24) & 0x0FF),
+				static_cast<value_type>((a_packedVersion >> 16) & 0x0FF),
+				static_cast<value_type>((a_packedVersion >> 4) & 0xFFF),
+				static_cast<value_type>(a_packedVersion & 0x0F)
+			};
+		}
 
 	private:
 		std::array<value_type, 4> _impl{ 0, 0, 0, 0 };
 	};
 
-	[[nodiscard]] constexpr bool operator==(const Version& a_lhs, const Version& a_rhs) noexcept { return a_lhs.compare(a_rhs) == std::strong_ordering::equal; }
+	[[nodiscard]] constexpr bool operator==(const Version& a_lhs, const Version& a_rhs) noexcept
+	{
+		return a_lhs.compare(a_rhs) == std::strong_ordering::equal;
+	}
 
-	[[nodiscard]] constexpr std::strong_ordering operator<=>(const Version& a_lhs, const Version& a_rhs) noexcept { return a_lhs.compare(a_rhs); }
+	[[nodiscard]] constexpr std::strong_ordering operator<=>(const Version& a_lhs, const Version& a_rhs) noexcept
+	{
+		return a_lhs.compare(a_rhs);
+	}
 
 	namespace literals
 	{
@@ -122,7 +139,10 @@ namespace REL
 			return REL::Version(result);
 		}
 
-		[[nodiscard]] constexpr REL::Version operator""_v(const char* str, std::size_t len) { return Version(std::string_view(str, len)); }
+		[[nodiscard]] constexpr REL::Version operator""_v(const char* str, std::size_t len)
+		{
+			return Version(std::string_view(str, len));
+		}
 	}  // namespace literals
 
 	[[nodiscard]] std::optional<Version> get_file_version(stl::zwstring a_filename);


### PR DESCRIPTION
- moved `Offset` to it's own header
- some formatting changes