### PR TITLE
feat: add concurrency key to maintenance.yml

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -7,7 +7,7 @@ on:
       - "CommonLibSF/**"
   workflow_dispatch:
 
-concurrency: main-ci
+concurrency: maintenance
 
 jobs:
   maintenance:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -7,7 +7,9 @@ on:
       - "CommonLibSF/**"
   workflow_dispatch:
 
-concurrency: maintenance
+concurrency:
+  group: maintenance
+  cancel-in-progress: true
 
 jobs:
   maintenance:

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -7,6 +7,8 @@ on:
       - "CommonLibSF/**"
   workflow_dispatch:
 
+concurrency: main-ci
+
 jobs:
   maintenance:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should ensure that there's no overlap between CI runs in case multiple pull requests are merged consecutively within a short period. I noticed the vcpkg repo update tends to fail if the repository dispatch event is sent by 2 or more overlapping workflows 