### PR TITLE
chore: add `explicit` to converting constructors for `Offset` and `Version`

### DIFF
--- a/CommonLibSF/include/REL/Offset.h
+++ b/CommonLibSF/include/REL/Offset.h
@@ -9,7 +9,7 @@ namespace REL
 	public:
 		constexpr Offset() = default;
 
-		constexpr Offset(const std::ptrdiff_t a_offset) :
+		explicit constexpr Offset(const std::ptrdiff_t a_offset) :
 			_offset(a_offset)
 		{}
 

--- a/CommonLibSF/include/REL/Version.h
+++ b/CommonLibSF/include/REL/Version.h
@@ -14,7 +14,7 @@ namespace REL
 		explicit constexpr Version(std::array<value_type, 4> a_version) noexcept :
 			_impl(a_version) {}
 
-		constexpr Version(value_type a_v1, value_type a_v2 = 0, value_type a_v3 = 0, value_type a_v4 = 0) noexcept :
+		explicit constexpr Version(value_type a_v1, value_type a_v2 = 0, value_type a_v3 = 0, value_type a_v4 = 0) noexcept :
 			_impl{ a_v1, a_v2, a_v3, a_v4 } {}
 
 		explicit constexpr Version(std::string_view a_version);

--- a/CommonLibSF/src/SFSE/Interfaces.cpp
+++ b/CommonLibSF/src/SFSE/Interfaces.cpp
@@ -11,7 +11,7 @@ namespace SFSE
 		const auto minor = static_cast<std::uint16_t>((packed & 0x00FF0000) >> 16);
 		const auto revision = static_cast<std::uint16_t>((packed & 0x0000FFF0) >> 4);
 		const auto build = static_cast<std::uint16_t>((packed & 0x0000000F) >> 0);
-		return { major, minor, revision, build };
+		return REL::Version{ major, minor, revision, build };
 	}
 
 	std::uint32_t QueryInterface::SFSEVersion() const { return GetProxy()->sfseVersion; }


### PR DESCRIPTION
Builds on #74 

Related: #65 