### PR TITLE
chore: update CommonLibSF.cmake to reflect #73 changes

### DIFF
--- a/CommonLibSF/cmake/CommonLibSF.cmake
+++ b/CommonLibSF/cmake/CommonLibSF.cmake
@@ -114,7 +114,6 @@ function(target_commonlibsf_properties TARGET)
 
     file(WRITE "${commonlibsf_plugin_file}"
             "#pragma once\n\n"
-            "#define SFSEPluginVersion extern \"C\" __declspec(dllexport) constinit SFSE::PluginVersionData SFSEPlugin_Version\n\n"
             "namespace Plugin\n"
             "{\n"
             "    using namespace std::string_view_literals;\n\n"


### PR DESCRIPTION
Just removes the `SFSEPluginVersion` macro from the script since the macro is part of the library now 