### PR TITLE
feat: Add TESWorldspace.h, decoding of TESObjectCell, GetParentWorldSpace for TESObjectRef* 

### DIFF
--- a/CommonLibSF/include/RE/Starfield.h
+++ b/CommonLibSF/include/RE/Starfield.h
@@ -93,3 +93,4 @@
 #include "RE/T/TESSpellList.h"
 #include "RE/T/TESTopicInfo.h"
 #include "RE/U/UI.h"
+#include "RE/T/TESWorldSpace.h"

--- a/CommonLibSF/include/RE/T/TESObjectCELL.h
+++ b/CommonLibSF/include/RE/T/TESObjectCELL.h
@@ -2,6 +2,7 @@
 
 #include "RE/T/TESForm.h"
 #include "RE/T/TESFullName.h"
+#include "RE/T/TESWorldSpace.h"
 
 namespace RE
 {

--- a/CommonLibSF/include/RE/T/TESObjectCELL.h
+++ b/CommonLibSF/include/RE/T/TESObjectCELL.h
@@ -13,6 +13,7 @@ namespace RE
 	public:
 		SF_RTTI_VTABLE(TESObjectCELL);
 		SF_FORMTYPE(CELL);
+
 		std::uint8_t        pad[0xD8];
 		TESWorldSpace* cellWorldspace;  //120
 	};

--- a/CommonLibSF/include/RE/T/TESObjectCELL.h
+++ b/CommonLibSF/include/RE/T/TESObjectCELL.h
@@ -12,7 +12,7 @@ namespace RE
 	public:
 		SF_RTTI_VTABLE(TESObjectCELL);
 		SF_FORMTYPE(CELL);
-
-		//
+		std::uint8_t        pad[0xD8];
+		TESWorldSpace* cellWorldspace;  //120
 	};
 }

--- a/CommonLibSF/include/RE/T/TESObjectREFR.h
+++ b/CommonLibSF/include/RE/T/TESObjectREFR.h
@@ -8,6 +8,7 @@
 #include "RE/I/IPostAnimationChannelUpdateFunctor.h"
 #include "RE/N/NiPoint3.h"
 #include "RE/T/TESHandleForm.h"
+#include "RE/T/TESWorldSpace.h"
 
 namespace RE
 {
@@ -284,6 +285,7 @@ namespace RE
 
 		// NiPointer<TESObjectREFR>
 		[[nodiscard]] TESObjectREFR* GetAttachedSpaceship();
+		[[nodiscard]] TESWorldSpace* GetParentWorldSpace();
 
 		[[nodiscard]] TESBoundObject*       GetBaseObject() { return data.objectReference; }
 		[[nodiscard]] const TESBoundObject* GetBaseObject() const { return data.objectReference; };

--- a/CommonLibSF/include/RE/T/TESWorldSpace.h
+++ b/CommonLibSF/include/RE/T/TESWorldSpace.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "RE/T/TESForm.h"
+#include "RE/T/TESFullName.h"
+
+class TESWorldSpace : public RE::TESForm,    // 00
+    public RE::TESFullName // 20
+{
+public:
+    SF_FORMTYPE(WRLD);
+};

--- a/CommonLibSF/src/RE/T/TESObjectREFR.cpp
+++ b/CommonLibSF/src/RE/T/TESObjectREFR.cpp
@@ -9,6 +9,13 @@ namespace RE
 		return func(this);
 	}
 
+	TESWorldSpace* TESObjectREFR::GetParentWorldSpace()
+	{
+		using func_t = decltype(&TESObjectREFR::GetParentWorldSpace);
+		REL::Relocation<func_t> func{ REL::Offset(0x01A093BC) };
+		return func(this);
+	}
+
 	std::int32_t TESObjectREFR::GetValue()
 	{
 		using func_t = decltype(&TESObjectREFR::GetValue);


### PR DESCRIPTION
I realised that I placed TESWorldspace.h to \W\ subfolder on the previous pull request.

This pull request should account for all previously requested changes.