### PR TITLE
fix!: consolelog print/vprint

### DIFF
--- a/CommonLibSF/include/RE/C/ConsoleLog.h
+++ b/CommonLibSF/include/RE/C/ConsoleLog.h
@@ -14,9 +14,17 @@ namespace RE
 			return *singleton;
 		}
 
-		void Print(const char* a_fmt, std::va_list a_args)
+		void Print(const char* a_fmt, ...)
 		{
-			using func_t = decltype(&ConsoleLog::Print);
+			std::va_list args;
+			va_start(args, a_fmt);
+			VPrint(a_fmt, args);
+			va_end(args);
+		}
+
+		void VPrint(const char* a_fmt, std::va_list a_args)
+		{
+			using func_t = decltype(&ConsoleLog::VPrint);
 			REL::Relocation<func_t> func{ REL::Offset(0x02883978) };
 			func(this, a_fmt, a_args);
 		}


### PR DESCRIPTION
`ConsoleLog::Print` accepts a variadic *object* and should be called `VPrint`, while `Print` accepts variadic *arguments*.

This might cause Squeegee to have an aneurism, but I don't think very many people were paying attention when things were added a while ago. I do agree that pr's should stay in the oven a while longer to catch things like this.

PS: Still not entirely used to conventional commits.
PPS: All hail the march of progress!