### PR TITLE
fix!: add missing bool argument to `TESObjectREFR::IsInSpace`, `TESObjectREFR::GetAttachedSpaceship`

### DIFF
--- a/CommonLibSF/include/RE/T/TESObjectREFR.h
+++ b/CommonLibSF/include/RE/T/TESObjectREFR.h
@@ -279,13 +279,10 @@ namespace RE
 		virtual void         Unk_12E();                                                                                                                         // 12E
 		virtual void         Unk_12F();                                                                                                                         // 12F
 
-		[[nodiscard]] constexpr NiPoint3A GetAngle() const { return data.angle; }
-		[[nodiscard]] constexpr float     GetAngleX() const { return data.angle.x; }
-		[[nodiscard]] constexpr float     GetAngleY() const { return data.angle.y; }
-		[[nodiscard]] constexpr float     GetAngleZ() const { return data.angle.z; }
-
-		// NiPointer<TESObjectREFR>
-		[[nodiscard]] TESObjectREFR*        GetAttachedSpaceship();
+		[[nodiscard]] constexpr NiPoint3A   GetAngle() const { return data.angle; }
+		[[nodiscard]] constexpr float       GetAngleX() const { return data.angle.x; }
+		[[nodiscard]] constexpr float       GetAngleY() const { return data.angle.y; }
+		[[nodiscard]] constexpr float       GetAngleZ() const { return data.angle.z; }
 		[[nodiscard]] TESBoundObject*       GetBaseObject() { return data.objectReference; }
 		[[nodiscard]] const TESBoundObject* GetBaseObject() const { return data.objectReference; };
 		[[nodiscard]] BGSLocation*          GetCurrentLocation();
@@ -295,12 +292,13 @@ namespace RE
 		[[nodiscard]] constexpr float       GetPositionX() const noexcept { return data.location.x; }
 		[[nodiscard]] constexpr float       GetPositionY() const noexcept { return data.location.y; }
 		[[nodiscard]] constexpr float       GetPositionZ() const noexcept { return data.location.z; }
+		[[nodiscard]] TESObjectREFR*        GetSpaceship(bool a_arg1 = true);
 		[[nodiscard]] TESObjectREFR*        GetSpaceshipParentDock();
 		[[nodiscard]] Actor*                GetSpaceshipPilot();
 		[[nodiscard]] std::int32_t          GetValue();
 		[[nodiscard]] bool                  HasKeyword(BGSKeyword* a_keyword);
 		[[nodiscard]] bool                  IsCrimeToActivate();
-		[[nodiscard]] bool                  IsInSpace();
+		[[nodiscard]] bool                  IsInSpace(bool a_arg1);
 
 		// members
 		std::uint32_t  unk80;          // 80

--- a/CommonLibSF/src/RE/T/TESObjectREFR.cpp
+++ b/CommonLibSF/src/RE/T/TESObjectREFR.cpp
@@ -2,13 +2,6 @@
 
 namespace RE
 {
-	TESObjectREFR* TESObjectREFR::GetAttachedSpaceship()
-	{
-		using func_t = decltype(&TESObjectREFR::GetAttachedSpaceship);
-		REL::Relocation<func_t> func{ REL::Offset(0x02B3A714) };
-		return func(this);
-	}
-
 	BGSLocation* TESObjectREFR::GetCurrentLocation()
 	{
 		using func_t = decltype(&TESObjectREFR::GetCurrentLocation);
@@ -28,6 +21,13 @@ namespace RE
 		using func_t = decltype(&TESObjectREFR::GetParentWorldSpace);
 		REL::Relocation<func_t> func{ REL::Offset(0x01A093BC) };
 		return func(this);
+	}
+
+	TESObjectREFR* TESObjectREFR::GetSpaceship(bool a_arg1)
+	{
+		using func_t = decltype(&TESObjectREFR::GetSpaceship);
+		REL::Relocation<func_t> func{ REL::Offset(0x02B3A714) };
+		return func(this, a_arg1);
 	}
 
 	TESObjectREFR* TESObjectREFR::GetSpaceshipParentDock()
@@ -65,10 +65,10 @@ namespace RE
 		return func(this);
 	}
 
-	bool TESObjectREFR::IsInSpace()
+	bool TESObjectREFR::IsInSpace(bool a_arg1)
 	{
 		using func_t = decltype(&TESObjectREFR::IsInSpace);
 		REL::Relocation<func_t> func{ REL::Offset(0x01A0E1C8) };
-		return func(this);
+		return func(this, a_arg1);
 	}
 }


### PR DESCRIPTION
- The argument is still unknown but it seems to be checking interior cell type (or state). 
- Also renamed `TESObjectREFR::GetAttachedSpaceship` to `TESObjectREFR::GetSpaceship` to match the recently added functions.