### PR TITLE
fix: SFSE plugin version data address/structure independence bits

### DIFF
--- a/CommonLibSF/include/SFSE/Interfaces.h
+++ b/CommonLibSF/include/SFSE/Interfaces.h
@@ -119,13 +119,13 @@ namespace SFSE
 
 		[[nodiscard]] constexpr std::string_view GetAuthorName() const noexcept { return std::string_view{ author }; }
 
-		constexpr void UsesSigScanning(bool a_value) noexcept { addressIndependence = 1 << static_cast<std::uint32_t>(!a_value); }
+		constexpr void UsesSigScanning(bool a_value) noexcept { addressIndependence = SetOrClearBit(addressIndependence, 1 << 0, a_value); }
 
-		constexpr void UsesAddressLibrary(bool a_value) noexcept { addressIndependence = 1 << static_cast<std::uint32_t>(a_value); }
+		constexpr void UsesAddressLibrary(bool a_value) noexcept { addressIndependence = SetOrClearBit(addressIndependence, 1 << 1, a_value); }
 
-		constexpr void HasNoStructUse(bool a_value) noexcept { structureCompatibility = 1 << static_cast<std::uint32_t>(!a_value); }
+		constexpr void HasNoStructUse(bool a_value) noexcept { structureCompatibility = SetOrClearBit(structureCompatibility, 1 << 0, a_value); }
 
-		constexpr void IsLayoutDependent(bool a_value) noexcept { structureCompatibility = 1 << static_cast<std::uint32_t>(a_value); }
+		constexpr void IsLayoutDependent(bool a_value) noexcept { structureCompatibility = SetOrClearBit(structureCompatibility, 1 << 1, a_value); }
 
 		constexpr void CompatibleVersions(std::initializer_list<REL::Version> a_versions) noexcept
 		{
@@ -155,6 +155,16 @@ namespace SFSE
 			assert(a_src.size() < a_dst.size());
 			std::ranges::fill(a_dst, '\0');
 			std::ranges::copy(a_src, a_dst.begin());
+		}
+		
+		[[nodiscard]] static constexpr std::uint32_t SetOrClearBit(std::uint32_t a_data, std::uint32_t a_bit, bool a_set) noexcept
+		{
+			if (a_set)
+				a_data |= a_bit;
+			else
+				a_data &= ~a_bit;
+			
+			return a_data;
 		}
 	};
 


### PR DESCRIPTION
These should be bitfields, like `TESForm::formFlags` for example.