### PR TITLE
feat: add MenuInterface + enum names

### DIFF
--- a/CommonLibSF/include/SFSE/Impl/Stubs.h
+++ b/CommonLibSF/include/SFSE/Impl/Stubs.h
@@ -41,5 +41,11 @@ namespace SFSE
 			void* (*AllocateFromBranchPool)(PluginHandle, std::size_t);
 			void* (*AllocateFromLocalPool)(PluginHandle, std::size_t);
 		};
+
+		struct SFSEMenuInterface
+		{
+			std::uint32_t interfaceVersion;
+			void (*Register)(void*);
+		};
 	}  // namespace detail
 }  // namespace SFSE

--- a/CommonLibSF/include/SFSE/Interfaces.h
+++ b/CommonLibSF/include/SFSE/Interfaces.h
@@ -3,6 +3,11 @@
 #include "SFSE/Impl/Stubs.h"
 #include "SFSE/Version.h"
 
+namespace RE
+{
+	class IMenu;
+}
+
 namespace SFSE
 {
 	struct PluginInfo;
@@ -20,11 +25,12 @@ namespace SFSE
 	class LoadInterface : public QueryInterface
 	{
 	public:
-		enum : std::uint32_t
+		enum InterfaceType : std::uint32_t
 		{
 			kInvalid = 0,
 			kMessaging,
 			kTrampoline,
+			kMenu,
 
 			kTotal
 		};
@@ -47,12 +53,12 @@ namespace SFSE
 
 		using EventCallback = std::add_pointer_t<void(Message* a_msg)>;
 
-		enum
+		enum Version : std::uint32_t
 		{
-			kVersion = 2
+			kVersion = 1
 		};
 
-		enum : std::uint32_t
+		enum MessageType : std::uint32_t
 		{
 			kPostLoad,
 			kPostPostLoad,
@@ -71,7 +77,7 @@ namespace SFSE
 	class TrampolineInterface
 	{
 	public:
-		enum
+		enum Version : std::uint32_t
 		{
 			kVersion = 1
 		};
@@ -85,9 +91,27 @@ namespace SFSE
 		[[nodiscard]] const detail::SFSETrampolineInterface* GetProxy() const;
 	};
 
+	class MenuInterface
+	{
+	public:
+		using RegCallback = void(RE::IMenu* a_menu);
+
+		enum Version : std::uint32_t
+		{
+			kVersion = 1
+		};
+
+		[[nodiscard]] std::uint32_t Version() const;
+
+		void Register(RegCallback* a_callback) const;
+
+	private:
+		[[nodiscard]] const detail::SFSEMenuInterface* GetProxy() const;
+	};
+
 	struct PluginInfo
 	{
-		enum
+		enum Version : std::uint32_t
 		{
 			kVersion = 1
 		};
@@ -100,9 +124,9 @@ namespace SFSE
 	struct PluginVersionData
 	{
 	public:
-		enum
+		enum Version : std::uint32_t
 		{
-			kVersion = 1,
+			kVersion = 1
 		};
 
 		constexpr void PluginVersion(std::uint32_t a_version) noexcept { pluginVersion = a_version; }

--- a/CommonLibSF/src/SFSE/API.cpp
+++ b/CommonLibSF/src/SFSE/API.cpp
@@ -18,8 +18,8 @@ namespace SFSE
 			std::uint32_t releaseIndex{ 0 };
 
 			TrampolineInterface* trampolineInterface{ nullptr };
-
 			MessagingInterface* messagingInterface{ nullptr };
+			MenuInterface* menuInterface{ nullptr };
 
 			std::mutex                         apiLock;
 			std::vector<std::function<void()>> apiInitRegs;
@@ -65,6 +65,7 @@ namespace SFSE
 
 			storage.messagingInterface = detail::QueryInterface<MessagingInterface>(a_intfc, LoadInterface::kMessaging);
 			storage.trampolineInterface = detail::QueryInterface<TrampolineInterface>(a_intfc, LoadInterface::kTrampoline);
+			storage.menuInterface = detail::QueryInterface<MenuInterface>(a_intfc, LoadInterface::kMenu);
 
 			storage.apiInit = true;
 			auto& regs = storage.apiInitRegs;
@@ -97,6 +98,11 @@ namespace SFSE
 	const TrampolineInterface* GetTrampolineInterface() noexcept { return detail::APIStorage::get().trampolineInterface; }
 
 	const MessagingInterface* GetMessagingInterface() noexcept { return detail::APIStorage::get().messagingInterface; }
+
+	const MenuInterface* GetMenuInterface() noexcept
+	{
+		return detail::APIStorage::get().menuInterface;
+	}
 
 	Trampoline& GetTrampoline()
 	{

--- a/CommonLibSF/src/SFSE/Interfaces.cpp
+++ b/CommonLibSF/src/SFSE/Interfaces.cpp
@@ -68,6 +68,22 @@ namespace SFSE
 		return reinterpret_cast<const detail::SFSETrampolineInterface*>(this);
 	}
 
+	std::uint32_t MenuInterface::Version() const
+	{
+		return GetProxy()->interfaceVersion;
+	}
+
+	void MenuInterface::Register(RegCallback* a_callback) const
+	{
+		return GetProxy()->Register(reinterpret_cast<void*>(a_callback));
+	}
+
+	const detail::SFSEMenuInterface* MenuInterface::GetProxy() const
+	{
+		assert(this);
+		return reinterpret_cast<const detail::SFSEMenuInterface*>(this);
+	}
+
 	const PluginVersionData* PluginVersionData::GetSingleton() noexcept
 	{
 		return reinterpret_cast<const PluginVersionData*>(WinAPI::GetProcAddress(WinAPI::GetCurrentModule(), "SFSEPlugin_Version"));


### PR DESCRIPTION
There are no `IMenu` classes yet so this is just the `SFSE` machinery.

The version number for `MessagingInterface` was incorrectly set to 2, it should be 1 as currently set in `SFSE`. This was likely a result of copy & paste from CLibSSE.

PS: I also named the enums for type discovery. I didn't make them `enum class` as that would be a breaking change and overkill.