### PR TITLE
feat!: script commands

### DIFF
--- a/CommonLibSF/include/RE/S/Script.h
+++ b/CommonLibSF/include/RE/S/Script.h
@@ -149,11 +149,11 @@ namespace RE
 
 		enum
 		{
-			kNumScriptCommands = 0x03C0,
 			kNumConsoleCommands = 0x0245,
+			kNumScriptCommands = 0x03C0,
 
-			kScriptOpBase = 0x1000,
 			kConsoleOpBase = 0x0100,
+			kScriptOpBase = 0x1000,
 		};
 
 		inline static SCRIPT_FUNCTION GetFirstScriptCommand()
@@ -166,6 +166,18 @@ namespace RE
 		{
 			static REL::Relocation<SCRIPT_FUNCTION> chunk{ REL::ID(841465) };
 			return chunk.get();
+		}
+
+		inline static const auto GetConsoleCommands()
+		{
+			static REL::Relocation<SCRIPT_FUNCTION(*)[kNumConsoleCommands]> chunk{ REL::ID(841465) };
+			return std::span{ *chunk };
+		}
+
+		inline static const auto GetScriptCommands()
+		{
+			static REL::Relocation<SCRIPT_FUNCTION(*)[kNumScriptCommands]> chunk{ REL::ID(841467) };
+			return std::span{ *chunk };
 		}
 
 		// members

--- a/CommonLibSF/include/RE/S/Script.h
+++ b/CommonLibSF/include/RE/S/Script.h
@@ -156,18 +156,6 @@ namespace RE
 			kScriptOpBase = 0x1000,
 		};
 
-		inline static SCRIPT_FUNCTION* GetFirstConsoleCommand()
-		{
-			static REL::Relocation<SCRIPT_FUNCTION*> chunk{ REL::ID(841465) };
-			return chunk.get();
-		}
-
-		inline static SCRIPT_FUNCTION* GetFirstScriptCommand()
-		{
-			static REL::Relocation<SCRIPT_FUNCTION*> chunk{ REL::ID(841467) };
-			return chunk.get();
-		}
-
 		inline static const auto GetConsoleCommands()
 		{
 			static REL::Relocation<SCRIPT_FUNCTION(*)[kNumConsoleCommands]> chunk{ REL::ID(841465) };

--- a/CommonLibSF/include/RE/S/Script.h
+++ b/CommonLibSF/include/RE/S/Script.h
@@ -156,15 +156,15 @@ namespace RE
 			kScriptOpBase = 0x1000,
 		};
 
-		inline static SCRIPT_FUNCTION GetFirstScriptCommand()
+		inline static SCRIPT_FUNCTION* GetFirstConsoleCommand()
 		{
-			static REL::Relocation<SCRIPT_FUNCTION> chunk{ REL::ID(841467) };
+			static REL::Relocation<SCRIPT_FUNCTION*> chunk{ REL::ID(841465) };
 			return chunk.get();
 		}
 
-		inline static SCRIPT_FUNCTION GetFirstConsoleCommand()
+		inline static SCRIPT_FUNCTION* GetFirstScriptCommand()
 		{
-			static REL::Relocation<SCRIPT_FUNCTION> chunk{ REL::ID(841465) };
+			static REL::Relocation<SCRIPT_FUNCTION*> chunk{ REL::ID(841467) };
 			return chunk.get();
 		}
 

--- a/CommonLibSF/include/RE/U/UI.h
+++ b/CommonLibSF/include/RE/U/UI.h
@@ -12,9 +12,8 @@ namespace RE
 		bool IsMenuOpen(const BSFixedString& a_name)
 		{
 			using func_t = decltype(&UI::IsMenuOpen);
-			REL::Relocation<func_t> func{ REL::ID(187048) };
+			REL::Relocation<func_t> func{ REL::ID(187049) };
 			return func(this, a_name);
 		}
 	};
-
 }


### PR DESCRIPTION
- add `Script::GetConsoleCommands` and `Script::GetScriptCommands`, these return a span allowing you to iterate over all of the commands.
- change the `GetFirst` functions to return a pointer to the command rather than a copy

With the new functions one could achieve pretty much the same result as the `GetFirst` functions by calling `front()` on the span, which begs the question: do we keep the old ones?