### PR TITLE
fix: undefine `BSTEventSource::Notify` argument

### DIFF
--- a/CommonLibSF/include/RE/B/BSTEvent.h
+++ b/CommonLibSF/include/RE/B/BSTEvent.h
@@ -49,7 +49,7 @@ namespace RE
 	public:
 		~BSTEventSource() override = default;  // 00
 
-		void Notify(const Event& a_event)
+		void Notify(void* a_event)
 		{
 			using func_t = decltype(&BSTEventSource::Notify);
 			REL::Relocation<func_t> func{ REL::ID(178573) };


### PR DESCRIPTION
Unlike F4 it passes in a more complex struct (event + local function lambda)