### PR TITLE
feat: add safer/convenient console log function

### DIFF
--- a/CommonLibSF/include/RE/C/ConsoleLog.h
+++ b/CommonLibSF/include/RE/C/ConsoleLog.h
@@ -14,6 +14,14 @@ namespace RE
 			return *singleton;
 		}
 
+		void VPrint(const char* a_fmt, std::va_list a_args)
+		{
+			using func_t = decltype(&ConsoleLog::VPrint);
+			REL::Relocation<func_t> func{ REL::ID(166358) };
+			func(this, a_fmt, a_args);
+		}
+
+		// printf format rules, no compile time checking
 		void Print(const char* a_fmt, ...)
 		{
 			std::va_list args;
@@ -22,11 +30,11 @@ namespace RE
 			va_end(args);
 		}
 
-		void VPrint(const char* a_fmt, std::va_list a_args)
+		// std::format rules, compile time checking
+		template <class... Args>
+		void Log(const std::format_string<Args...> a_fmt, Args&&... a_args)
 		{
-			using func_t = decltype(&ConsoleLog::VPrint);
-			REL::Relocation<func_t> func{ REL::ID(166358) };
-			func(this, a_fmt, a_args);
+			Print(std::vformat(a_fmt.get(), std::make_format_args(a_args...)).c_str());
 		}
 	};
 }


### PR DESCRIPTION
- this log function makes use of `std::format` and the benefits that comes with (compile time checking, type representation, numbered fields, etc.) compared to the printf style function.

```cpp
auto log = RE::ConsoleLog::GetSingleton();
log->Log("Value: {}", true);
```
```
Value: true
```