### PR TITLE
feat: add `NiSmartPointer`, support `TESForm` smart pointers

### DIFF
--- a/CommonLibSF/include/RE/N/NiSmartPointer.h
+++ b/CommonLibSF/include/RE/N/NiSmartPointer.h
@@ -151,7 +151,7 @@ namespace RE
 		// members
 		element_type* _ptr{ nullptr };  // 0
 	};
-	//static_assert(sizeof(NiPointer<void*>) == 0x8);
+	static_assert(sizeof(NiPointer<void*>) == 0x8);
 
 	template <class T, class... Args>
 	[[nodiscard]] NiPointer<T> make_nismart(Args&&... a_args)

--- a/CommonLibSF/include/RE/N/NiSmartPointer.h
+++ b/CommonLibSF/include/RE/N/NiSmartPointer.h
@@ -8,13 +8,10 @@ namespace RE
 	public:
 		using element_type = T;
 
-		// 1)
 		constexpr NiPointer() noexcept = default;
 
-		// 2)
 		constexpr NiPointer(std::nullptr_t) noexcept {}
 
-		// 3)
 		template <class Y>
 		explicit NiPointer(Y* a_rhs)  //
 			requires(std::convertible_to<Y*, element_type*>)
@@ -24,14 +21,12 @@ namespace RE
 			TryAttach();
 		}
 
-		// 9a)
 		NiPointer(const NiPointer& a_rhs) :
 			_ptr(a_rhs._ptr)
 		{
 			TryAttach();
 		}
 
-		// 9b)
 		template <class Y>
 		NiPointer(const NiPointer<Y>& a_rhs)  //
 			requires(std::convertible_to<Y*, element_type*>)
@@ -41,12 +36,10 @@ namespace RE
 			TryAttach();
 		}
 
-		// 10a)
 		NiPointer(NiPointer&& a_rhs) noexcept :
 			_ptr(std::exchange(a_rhs._ptr, nullptr))
 		{}
 
-		// 10b)
 		template <class Y>
 		NiPointer(NiPointer<Y>&& a_rhs) noexcept  //
 			requires(std::convertible_to<Y*, element_type*>)
@@ -56,7 +49,6 @@ namespace RE
 
 		~NiPointer() noexcept { reset(); }
 
-		// 1a)
 		NiPointer& operator=(const NiPointer& a_rhs)
 		{
 			if (this != std::addressof(a_rhs)) {
@@ -67,7 +59,6 @@ namespace RE
 			return *this;
 		}
 
-		// 1b)
 		template <class Y>
 		NiPointer& operator=(const NiPointer<Y>& a_rhs)  //
 			requires(std::convertible_to<Y*, element_type*>)
@@ -78,7 +69,6 @@ namespace RE
 			return *this;
 		}
 
-		// 2a)
 		NiPointer& operator=(NiPointer&& a_rhs) noexcept
 		{
 			if (this != std::addressof(a_rhs)) {
@@ -88,7 +78,6 @@ namespace RE
 			return *this;
 		}
 
-		// 2b)
 		template <class Y>
 		NiPointer& operator=(NiPointer<Y>&& a_rhs) noexcept  //
 			requires(std::convertible_to<Y*, element_type*>)
@@ -98,10 +87,8 @@ namespace RE
 			return *this;
 		}
 
-		// 1)
 		void reset() { TryDetach(); }
 
-		// 2)
 		template <class Y>
 		void reset(Y* a_ptr)  //
 			requires(std::convertible_to<Y*, element_type*>)
@@ -159,28 +146,24 @@ namespace RE
 		return NiPointer<T>{ new T(std::forward<Args>(a_args)...) };
 	}
 
-	// 1)
 	template <class T, class U>
 	[[nodiscard]] constexpr bool operator==(const NiPointer<T>& a_lhs, const NiPointer<U>& a_rhs) noexcept
 	{
 		return a_lhs.get() == a_rhs.get();
 	}
 
-	// 7)
 	template <class T, class U>
 	[[nodiscard]] constexpr std::strong_ordering operator<=>(const NiPointer<T>& a_lhs, const NiPointer<U>& a_rhs) noexcept
 	{
 		return std::compare_three_way{}(a_lhs.get(), a_rhs.get());
 	}
 
-	// 8)
 	template <class T>
 	[[nodiscard]] constexpr bool operator==(const NiPointer<T>& a_lhs, std::nullptr_t) noexcept
 	{
 		return !a_lhs;
 	}
 
-	// 20)
 	template <class T>
 	[[nodiscard]] constexpr std::strong_ordering operator<=>(const NiPointer<T>& a_lhs, std::nullptr_t) noexcept
 	{

--- a/CommonLibSF/include/RE/N/NiSmartPointer.h
+++ b/CommonLibSF/include/RE/N/NiSmartPointer.h
@@ -1,0 +1,196 @@
+#pragma once
+
+namespace RE
+{
+	template <class T>
+	class NiPointer
+	{
+	public:
+		using element_type = T;
+
+		// 1)
+		constexpr NiPointer() noexcept = default;
+
+		// 2)
+		constexpr NiPointer(std::nullptr_t) noexcept {}
+
+		// 3)
+		template <class Y>
+		explicit NiPointer(Y* a_rhs)  //
+			requires(std::convertible_to<Y*, element_type*>)
+			:
+			_ptr(static_cast<element_type*>(a_rhs))
+		{
+			TryAttach();
+		}
+
+		// 9a)
+		NiPointer(const NiPointer& a_rhs) :
+			_ptr(a_rhs._ptr)
+		{
+			TryAttach();
+		}
+
+		// 9b)
+		template <class Y>
+		NiPointer(const NiPointer<Y>& a_rhs)  //
+			requires(std::convertible_to<Y*, element_type*>)
+			:
+			_ptr(static_cast<element_type*>(a_rhs._ptr))
+		{
+			TryAttach();
+		}
+
+		// 10a)
+		NiPointer(NiPointer&& a_rhs) noexcept :
+			_ptr(std::exchange(a_rhs._ptr, nullptr))
+		{}
+
+		// 10b)
+		template <class Y>
+		NiPointer(NiPointer<Y>&& a_rhs) noexcept  //
+			requires(std::convertible_to<Y*, element_type*>)
+			:
+			_ptr(static_cast<element_type*>(std::exchange(a_rhs._ptr, nullptr)))
+		{}
+
+		~NiPointer() noexcept { reset(); }
+
+		// 1a)
+		NiPointer& operator=(const NiPointer& a_rhs)
+		{
+			if (this != std::addressof(a_rhs)) {
+				TryDetach();
+				_ptr = a_rhs._ptr;
+				TryAttach();
+			}
+			return *this;
+		}
+
+		// 1b)
+		template <class Y>
+		NiPointer& operator=(const NiPointer<Y>& a_rhs)  //
+			requires(std::convertible_to<Y*, element_type*>)
+		{
+			TryDetach();
+			_ptr = static_cast<element_type*>(a_rhs._ptr);
+			TryAttach();
+			return *this;
+		}
+
+		// 2a)
+		NiPointer& operator=(NiPointer&& a_rhs) noexcept
+		{
+			if (this != std::addressof(a_rhs)) {
+				TryDetach();
+				_ptr = std::exchange(a_rhs._ptr, nullptr);
+			}
+			return *this;
+		}
+
+		// 2b)
+		template <class Y>
+		NiPointer& operator=(NiPointer<Y>&& a_rhs) noexcept  //
+			requires(std::convertible_to<Y*, element_type*>)
+		{
+			TryDetach();
+			_ptr = std::exchange(a_rhs._ptr, nullptr);
+			return *this;
+		}
+
+		// 1)
+		void reset() { TryDetach(); }
+
+		// 2)
+		template <class Y>
+		void reset(Y* a_ptr)  //
+			requires(std::convertible_to<Y*, element_type*>)
+		{
+			if (_ptr != a_ptr) {
+				TryDetach();
+				_ptr = static_cast<element_type*>(a_ptr);
+				TryAttach();
+			}
+		}
+
+		[[nodiscard]] constexpr element_type* get() const noexcept { return _ptr; }
+
+		[[nodiscard]] explicit constexpr operator bool() const noexcept { return _ptr != nullptr; }
+
+		[[nodiscard]] constexpr element_type& operator*() const noexcept
+		{
+			assert(static_cast<bool>(*this));
+			return *_ptr;
+		}
+
+		[[nodiscard]] constexpr element_type* operator->() const noexcept
+		{
+			assert(static_cast<bool>(*this));
+			return _ptr;
+		}
+
+	protected:
+		template <class>
+		friend class NiPointer;
+
+		void TryAttach()
+		{
+			if (_ptr) {
+				_ptr->IncRefCount();
+			}
+		}
+
+		void TryDetach()
+		{
+			if (_ptr) {
+				_ptr->DecRefCount();
+				_ptr = nullptr;
+			}
+		}
+
+		// members
+		element_type* _ptr{ nullptr };  // 0
+	};
+	//static_assert(sizeof(NiPointer<void*>) == 0x8);
+
+	template <class T, class... Args>
+	[[nodiscard]] NiPointer<T> make_nismart(Args&&... a_args)
+	{
+		return NiPointer<T>{ new T(std::forward<Args>(a_args)...) };
+	}
+
+	// 1)
+	template <class T, class U>
+	[[nodiscard]] constexpr bool operator==(const NiPointer<T>& a_lhs, const NiPointer<U>& a_rhs) noexcept
+	{
+		return a_lhs.get() == a_rhs.get();
+	}
+
+	// 7)
+	template <class T, class U>
+	[[nodiscard]] constexpr std::strong_ordering operator<=>(const NiPointer<T>& a_lhs, const NiPointer<U>& a_rhs) noexcept
+	{
+		return std::compare_three_way{}(a_lhs.get(), a_rhs.get());
+	}
+
+	// 8)
+	template <class T>
+	[[nodiscard]] constexpr bool operator==(const NiPointer<T>& a_lhs, std::nullptr_t) noexcept
+	{
+		return !a_lhs;
+	}
+
+	// 20)
+	template <class T>
+	[[nodiscard]] constexpr std::strong_ordering operator<=>(const NiPointer<T>& a_lhs, std::nullptr_t) noexcept
+	{
+		return std::compare_three_way{}(a_lhs.get(), static_cast<typename NiPointer<T>::element_type*>(nullptr));
+	}
+
+	template <class T>
+	NiPointer(T*) -> NiPointer<T>;
+}
+
+#define NiSmartPointer(className) \
+	class className;              \
+	using className##Ptr = RE::NiPointer<className>

--- a/CommonLibSF/include/RE/T/TESForm.h
+++ b/CommonLibSF/include/RE/T/TESForm.h
@@ -120,6 +120,13 @@ namespace RE
 		virtual void                               Unk_60();                                                         // 60
 		virtual void                               Unk_61();                                                         // 61
 
+		std::uint64_t DecRefCount() const
+		{
+			using func_t = decltype(&TESForm::DecRefCount);
+			REL::Relocation<func_t> func{ REL::ID(35164) };
+			return func(this);
+		}
+
 		[[nodiscard]] static TESForm* LookupByID(std::uint32_t a_formID)
 		{
 			using func_t = decltype(&TESForm::LookupByID);

--- a/CommonLibSF/include/RE/T/TESFormRefCount.h
+++ b/CommonLibSF/include/RE/T/TESFormRefCount.h
@@ -9,6 +9,14 @@ namespace RE
 	public:
 		SF_RTTI(TESFormRefCount);
 
+		enum
+		{
+			kRefCountMask = 0x3FFFFF,
+		};
+
+		std::uint64_t               IncRefCount() const;
+		[[nodiscard]] std::uint64_t QRefCount() const;
+
 		// members
 		volatile mutable std::uint64_t refCount;  // 08
 	};

--- a/CommonLibSF/src/RE/T/TESFormRefCount.cpp
+++ b/CommonLibSF/src/RE/T/TESFormRefCount.cpp
@@ -1,4 +1,15 @@
 #include "RE/T/TESFormRefCount.h"
+
 namespace RE
 {
+	std::uint64_t TESFormRefCount::IncRefCount() const
+	{
+		stl::atomic_ref myRefCount{ refCount };
+		return ++myRefCount;
+	}
+
+	std::uint64_t TESFormRefCount::QRefCount() const
+	{
+		return refCount & kRefCountMask;
+	}
 }


### PR DESCRIPTION
- the function `DecRefCount` has been moved to `TESForm` because it calls `TESForm` specific vfuncs (0xB, 0xD, 0xE)