### PR TITLE
chore: remove empty compilation units

### DIFF
--- a/CommonLibSF/src/RE/A/Actor.cpp
+++ b/CommonLibSF/src/RE/A/Actor.cpp
@@ -1,1 +1,0 @@
-#include "RE/A/Actor.h"

--- a/CommonLibSF/src/RE/A/ActorValueInfo.cpp
+++ b/CommonLibSF/src/RE/A/ActorValueInfo.cpp
@@ -1,1 +1,0 @@
-#include "RE/A/ActorValueInfo.h"

--- a/CommonLibSF/src/RE/A/ActorValueOwner.cpp
+++ b/CommonLibSF/src/RE/A/ActorValueOwner.cpp
@@ -1,1 +1,0 @@
-#include "RE/A/ActorValueOwner.h"

--- a/CommonLibSF/src/RE/A/ActorValues.cpp
+++ b/CommonLibSF/src/RE/A/ActorValues.cpp
@@ -1,4 +1,0 @@
-#include "RE/A/ActorValues.h"
-namespace RE
-{
-}

--- a/CommonLibSF/src/RE/B/BGSAttackDataForm.cpp
+++ b/CommonLibSF/src/RE/B/BGSAttackDataForm.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BGSAttackDataForm.h"

--- a/CommonLibSF/src/RE/B/BGSDestructibleObjectForm.cpp
+++ b/CommonLibSF/src/RE/B/BGSDestructibleObjectForm.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BGSDestructibleObjectForm.h"

--- a/CommonLibSF/src/RE/B/BGSForcedLocRefType.cpp
+++ b/CommonLibSF/src/RE/B/BGSForcedLocRefType.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BGSForcedLocRefType.h"

--- a/CommonLibSF/src/RE/B/BGSKeyword.cpp
+++ b/CommonLibSF/src/RE/B/BGSKeyword.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BGSKeyword.h"

--- a/CommonLibSF/src/RE/B/BGSKeywordForm.cpp
+++ b/CommonLibSF/src/RE/B/BGSKeywordForm.cpp
@@ -1,4 +1,0 @@
-#include "RE/B/BGSKeywordForm.h"
-namespace RE
-{
-}

--- a/CommonLibSF/src/RE/B/BGSListForm.cpp
+++ b/CommonLibSF/src/RE/B/BGSListForm.cpp
@@ -1,4 +1,0 @@
-#include "RE/B/BGSListForm.h"
-namespace RE
-{
-}

--- a/CommonLibSF/src/RE/B/BGSLocation.cpp
+++ b/CommonLibSF/src/RE/B/BGSLocation.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BGSLocation.h"

--- a/CommonLibSF/src/RE/B/BGSLocationRefType.cpp
+++ b/CommonLibSF/src/RE/B/BGSLocationRefType.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BGSLocationRefType.h"

--- a/CommonLibSF/src/RE/B/BGSMod.cpp
+++ b/CommonLibSF/src/RE/B/BGSMod.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BGSMod.h"

--- a/CommonLibSF/src/RE/B/BGSNativeTerminalForm.cpp
+++ b/CommonLibSF/src/RE/B/BGSNativeTerminalForm.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BGSNativeTerminalForm.h"

--- a/CommonLibSF/src/RE/B/BGSObjectPlacementDefaults.cpp
+++ b/CommonLibSF/src/RE/B/BGSObjectPlacementDefaults.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BGSObjectPlacementDefaults.h"

--- a/CommonLibSF/src/RE/B/BGSOverridePackCollection.cpp
+++ b/CommonLibSF/src/RE/B/BGSOverridePackCollection.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BGSOverridePackCollection.h"

--- a/CommonLibSF/src/RE/B/BGSPerk.cpp
+++ b/CommonLibSF/src/RE/B/BGSPerk.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BGSPerk.h"

--- a/CommonLibSF/src/RE/B/BGSPerkRankArray.cpp
+++ b/CommonLibSF/src/RE/B/BGSPerkRankArray.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BGSPerkRankArray.h"

--- a/CommonLibSF/src/RE/B/BGSPreviewTransform.cpp
+++ b/CommonLibSF/src/RE/B/BGSPreviewTransform.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BGSPreviewTransform.h"

--- a/CommonLibSF/src/RE/B/BGSPropertySheet.cpp
+++ b/CommonLibSF/src/RE/B/BGSPropertySheet.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BGSPropertySheet.h"

--- a/CommonLibSF/src/RE/B/BGSScene.cpp
+++ b/CommonLibSF/src/RE/B/BGSScene.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BGSScene.h"

--- a/CommonLibSF/src/RE/B/BGSSkinForm.cpp
+++ b/CommonLibSF/src/RE/B/BGSSkinForm.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BGSSkinForm.h"

--- a/CommonLibSF/src/RE/B/BGSSnapTemplateComponent.cpp
+++ b/CommonLibSF/src/RE/B/BGSSnapTemplateComponent.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BGSSnapTemplateComponent.h"

--- a/CommonLibSF/src/RE/B/BGSTerminal.cpp
+++ b/CommonLibSF/src/RE/B/BGSTerminal.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BGSTerminal.h"

--- a/CommonLibSF/src/RE/B/BSFixedString.cpp
+++ b/CommonLibSF/src/RE/B/BSFixedString.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BSFixedString.h"

--- a/CommonLibSF/src/RE/B/BSIntrusiveRefCounted.cpp
+++ b/CommonLibSF/src/RE/B/BSIntrusiveRefCounted.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BSIntrusiveRefCounted.h"

--- a/CommonLibSF/src/RE/B/BSReflection.cpp
+++ b/CommonLibSF/src/RE/B/BSReflection.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BSReflection.h"

--- a/CommonLibSF/src/RE/B/BSStringT.cpp
+++ b/CommonLibSF/src/RE/B/BSStringT.cpp
@@ -1,4 +1,0 @@
-#include "RE/B/BSStringT.h"
-namespace RE
-{
-}

--- a/CommonLibSF/src/RE/B/BSTEvent.cpp
+++ b/CommonLibSF/src/RE/B/BSTEvent.cpp
@@ -1,4 +1,0 @@
-#include "RE/B/BSTEvent.h"
-namespace RE
-{
-}

--- a/CommonLibSF/src/RE/B/BSTList.cpp
+++ b/CommonLibSF/src/RE/B/BSTList.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BSTList.h"

--- a/CommonLibSF/src/RE/B/BaseFormComponent.cpp
+++ b/CommonLibSF/src/RE/B/BaseFormComponent.cpp
@@ -1,1 +1,0 @@
-#include "RE/B/BaseFormComponent.h"

--- a/CommonLibSF/src/RE/C/CombatGroup.cpp
+++ b/CommonLibSF/src/RE/C/CombatGroup.cpp
@@ -1,4 +1,0 @@
-#include "RE/C/CombatGroup.h"
-namespace RE
-{
-}

--- a/CommonLibSF/src/RE/C/ConsoleLog.cpp
+++ b/CommonLibSF/src/RE/C/ConsoleLog.cpp
@@ -1,1 +1,0 @@
-#include "RE/C/ConsoleLog.h"

--- a/CommonLibSF/src/RE/I/IAnimationGraphManagerHolder.cpp
+++ b/CommonLibSF/src/RE/I/IAnimationGraphManagerHolder.cpp
@@ -1,4 +1,0 @@
-﻿#include "RE/I/IAnimationGraphManagerHolder.h"
-namespace RE
-{
-}

--- a/CommonLibSF/src/RE/I/IFunction.cpp
+++ b/CommonLibSF/src/RE/I/IFunction.cpp
@@ -1,1 +1,0 @@
-#include "RE/I/IFunction.h"

--- a/CommonLibSF/src/RE/I/IKeywordFormBase.cpp
+++ b/CommonLibSF/src/RE/I/IKeywordFormBase.cpp
@@ -1,1 +1,0 @@
-#include "RE/I/IKeywordFormBase.h"

--- a/CommonLibSF/src/RE/I/IMovementInterface.cpp
+++ b/CommonLibSF/src/RE/I/IMovementInterface.cpp
@@ -1,4 +1,0 @@
-﻿#include "RE/I/IMovementInterface.h"
-namespace RE
-{
-}

--- a/CommonLibSF/src/RE/I/INIPrefSettingCollection.cpp
+++ b/CommonLibSF/src/RE/I/INIPrefSettingCollection.cpp
@@ -1,1 +1,0 @@
-#include "RE/I/INIPrefSettingCollection.h"

--- a/CommonLibSF/src/RE/I/INISettingCollection.cpp
+++ b/CommonLibSF/src/RE/I/INISettingCollection.cpp
@@ -1,1 +1,0 @@
-#include "RE/I/INISettingCollection.h"

--- a/CommonLibSF/src/RE/I/IPostAnimationChannelUpdateFunctor.cpp
+++ b/CommonLibSF/src/RE/I/IPostAnimationChannelUpdateFunctor.cpp
@@ -1,4 +1,0 @@
-﻿#include "RE/I/IPostAnimationChannelUpdateFunctor.h"
-namespace RE
-{
-}

--- a/CommonLibSF/src/RE/M/MemoryManager.cpp
+++ b/CommonLibSF/src/RE/M/MemoryManager.cpp
@@ -1,4 +1,0 @@
-#include "RE/M/MemoryManager.h"
-namespace RE
-{
-}

--- a/CommonLibSF/src/RE/M/MenuOpenCloseEvent.cpp
+++ b/CommonLibSF/src/RE/M/MenuOpenCloseEvent.cpp
@@ -1,4 +1,0 @@
-#include "RE/M/MenuOpenCloseEvent.h"
-namespace RE
-{
-}

--- a/CommonLibSF/src/RE/N/NativeFunction.cpp
+++ b/CommonLibSF/src/RE/N/NativeFunction.cpp
@@ -1,1 +1,0 @@
-#include "RE/N/NativeFunction.h"

--- a/CommonLibSF/src/RE/N/NativeFunctionBase.cpp
+++ b/CommonLibSF/src/RE/N/NativeFunctionBase.cpp
@@ -1,1 +1,0 @@
-#include "RE/N/NativeFunctionBase.h"

--- a/CommonLibSF/src/RE/R/RegSettingCollection.cpp
+++ b/CommonLibSF/src/RE/R/RegSettingCollection.cpp
@@ -1,1 +1,0 @@
-#include "RE/R/RegSettingCollection.h"

--- a/CommonLibSF/src/RE/S/Script.cpp
+++ b/CommonLibSF/src/RE/S/Script.cpp
@@ -1,1 +1,0 @@
-#include "RE/S/Script.h"

--- a/CommonLibSF/src/RE/S/SettingCollection.cpp
+++ b/CommonLibSF/src/RE/S/SettingCollection.cpp
@@ -1,1 +1,0 @@
-#include "RE/S/SettingCollection.h"

--- a/CommonLibSF/src/RE/S/SettingCollectionList.cpp
+++ b/CommonLibSF/src/RE/S/SettingCollectionList.cpp
@@ -1,1 +1,0 @@
-#include "RE/S/SettingCollectionList.h"

--- a/CommonLibSF/src/RE/S/SettingCollectionMap.cpp
+++ b/CommonLibSF/src/RE/S/SettingCollectionMap.cpp
@@ -1,1 +1,0 @@
-#include "RE/S/SettingCollectionMap.h"

--- a/CommonLibSF/src/RE/S/Settings.cpp
+++ b/CommonLibSF/src/RE/S/Settings.cpp
@@ -1,1 +1,0 @@
-#include "RE/S/Settings.h"

--- a/CommonLibSF/src/RE/Starfield.cpp
+++ b/CommonLibSF/src/RE/Starfield.cpp
@@ -1,1 +1,0 @@
-#include "RE/Starfield.h"

--- a/CommonLibSF/src/RE/T/TBO_InstanceData.cpp
+++ b/CommonLibSF/src/RE/T/TBO_InstanceData.cpp
@@ -1,4 +1,0 @@
-#include "RE/T/TBO_InstanceData.h"
-namespace RE
-{
-}

--- a/CommonLibSF/src/RE/T/TESAIForm.cpp
+++ b/CommonLibSF/src/RE/T/TESAIForm.cpp
@@ -1,1 +1,0 @@
-#include "RE/T/TESAIForm.h"

--- a/CommonLibSF/src/RE/T/TESActorBase.cpp
+++ b/CommonLibSF/src/RE/T/TESActorBase.cpp
@@ -1,1 +1,0 @@
-#include "RE/T/TESActorBase.h"

--- a/CommonLibSF/src/RE/T/TESActorBaseData.cpp
+++ b/CommonLibSF/src/RE/T/TESActorBaseData.cpp
@@ -1,1 +1,0 @@
-#include "RE/T/TESActorBaseData.h"

--- a/CommonLibSF/src/RE/T/TESBoundAnimObject.cpp
+++ b/CommonLibSF/src/RE/T/TESBoundAnimObject.cpp
@@ -1,1 +1,0 @@
-#include "RE/T/TESBoundAnimObject.h"

--- a/CommonLibSF/src/RE/T/TESBoundObject.cpp
+++ b/CommonLibSF/src/RE/T/TESBoundObject.cpp
@@ -1,1 +1,0 @@
-#include "RE/T/TESBoundObject.h"

--- a/CommonLibSF/src/RE/T/TESCamera.cpp
+++ b/CommonLibSF/src/RE/T/TESCamera.cpp
@@ -1,4 +1,0 @@
-﻿#include "RE/T/TESCamera.h"
-namespace RE
-{
-}

--- a/CommonLibSF/src/RE/T/TESContainer.cpp
+++ b/CommonLibSF/src/RE/T/TESContainer.cpp
@@ -1,1 +1,0 @@
-#include "RE/T/TESContainer.h"

--- a/CommonLibSF/src/RE/T/TESFile.cpp
+++ b/CommonLibSF/src/RE/T/TESFile.cpp
@@ -1,1 +1,0 @@
-#include "RE/T/TESFile.h"

--- a/CommonLibSF/src/RE/T/TESForm.cpp
+++ b/CommonLibSF/src/RE/T/TESForm.cpp
@@ -1,1 +1,0 @@
-#include "RE/T/TESForm.h"

--- a/CommonLibSF/src/RE/T/TESFullName.cpp
+++ b/CommonLibSF/src/RE/T/TESFullName.cpp
@@ -1,1 +1,0 @@
-#include "RE/T/TESFullName.h"

--- a/CommonLibSF/src/RE/T/TESHandleForm.cpp
+++ b/CommonLibSF/src/RE/T/TESHandleForm.cpp
@@ -1,4 +1,0 @@
-﻿#include "RE/T/TESHandleForm.h"
-namespace RE
-{
-}

--- a/CommonLibSF/src/RE/T/TESNPC.cpp
+++ b/CommonLibSF/src/RE/T/TESNPC.cpp
@@ -1,1 +1,0 @@
-#include "RE/T/TESNPC.h"

--- a/CommonLibSF/src/RE/T/TESObject.cpp
+++ b/CommonLibSF/src/RE/T/TESObject.cpp
@@ -1,1 +1,0 @@
-#include "RE/T/TESObject.h"

--- a/CommonLibSF/src/RE/T/TESObjectARMO.cpp
+++ b/CommonLibSF/src/RE/T/TESObjectARMO.cpp
@@ -1,1 +1,0 @@
-#include "RE/T/TESObjectARMO.h"

--- a/CommonLibSF/src/RE/T/TESObjectCELL.cpp
+++ b/CommonLibSF/src/RE/T/TESObjectCELL.cpp
@@ -1,1 +1,0 @@
-#include "RE/T/TESObjectCELL.h"

--- a/CommonLibSF/src/RE/T/TESQuest.cpp
+++ b/CommonLibSF/src/RE/T/TESQuest.cpp
@@ -1,4 +1,0 @@
-#include "RE/T/TESQuest.h"
-namespace RE
-{
-}

--- a/CommonLibSF/src/RE/T/TESRace.cpp
+++ b/CommonLibSF/src/RE/T/TESRace.cpp
@@ -1,1 +1,0 @@
-#include "RE/T/TESRace.h"

--- a/CommonLibSF/src/RE/T/TESRaceForm.cpp
+++ b/CommonLibSF/src/RE/T/TESRaceForm.cpp
@@ -1,1 +1,0 @@
-#include "RE/T/TESRaceForm.h"

--- a/CommonLibSF/src/RE/T/TESResponse.cpp
+++ b/CommonLibSF/src/RE/T/TESResponse.cpp
@@ -1,4 +1,0 @@
-#include "RE/T/TESResponse.h"
-
-namespace RE
-{}

--- a/CommonLibSF/src/RE/T/TESSpellList.cpp
+++ b/CommonLibSF/src/RE/T/TESSpellList.cpp
@@ -1,1 +1,0 @@
-#include "RE/T/TESSpellList.h"

--- a/CommonLibSF/src/RE/T/TESTopicInfo.cpp
+++ b/CommonLibSF/src/RE/T/TESTopicInfo.cpp
@@ -1,1 +1,0 @@
-#include "RE/T/TESTopicInfo.h"

--- a/CommonLibSF/src/SFSE/Impl/PCH.cpp
+++ b/CommonLibSF/src/SFSE/Impl/PCH.cpp
@@ -1,1 +1,0 @@
-#include "SFSE/Impl/PCH.h"


### PR DESCRIPTION
compilation time cost incurred by empty units

before:
- fresh: ~9.532s
- rebuild: ~7.547s

after:
- fresh: ~8.391s
- rebuild: ~6.516s

Obviously this isn't an in-depth test, but it does show why the use of compilation units should be kept to a minimum. As the project grows the time to compile will naturally grow, but we shouldn't introduce unnecessary delays on top.

PS: a large portion is taken up by the PCH, which makes sense.