### PR TITLE
feat!: make plugin version return Version instead

### DIFF
--- a/CommonLibSF/include/REL/Version.h
+++ b/CommonLibSF/include/REL/Version.h
@@ -151,14 +151,14 @@ namespace REL
 #ifdef __cpp_lib_format
 namespace std
 {
-    template<class CharT>
-    struct formatter<REL::Version, CharT> : formatter<std::string, CharT>
+	template<class CharT>
+	struct formatter<REL::Version, CharT> : formatter<std::string, CharT>
 	{
-        template<class FormatContext>
-        auto format(const REL::Version &a_version, FormatContext &a_ctx)
+		template<class FormatContext>
+		auto format(const REL::Version a_version, FormatContext& a_ctx) const
 		{
-            return formatter<std::string, CharT>::format(a_version.string(), a_ctx);
-        }
-    };
+			return formatter<std::string, CharT>::format(a_version.string(), a_ctx);
+		}
+	};
 }
 #endif

--- a/CommonLibSF/include/REL/Version.h
+++ b/CommonLibSF/include/REL/Version.h
@@ -55,7 +55,7 @@ namespace REL
 		[[nodiscard]] constexpr value_type patch() const noexcept { return _impl[2]; }
 		[[nodiscard]] constexpr value_type build() const noexcept { return _impl[3]; }
 
-		[[nodiscard]] std::string string(std::string_view a_separator = "-"sv) const
+		[[nodiscard]] std::string string(std::string_view a_separator = "."sv) const
 		{
 			std::string result;
 			for (auto&& ver : _impl) {
@@ -66,7 +66,7 @@ namespace REL
 			return result;
 		}
 
-		[[nodiscard]] std::wstring wstring(std::wstring_view a_separator = L"-"sv) const
+		[[nodiscard]] std::wstring wstring(std::wstring_view a_separator = L"."sv) const
 		{
 			std::wstring result;
 			for (auto&& ver : _impl) {
@@ -147,3 +147,18 @@ namespace REL
 
 	[[nodiscard]] std::optional<Version> get_file_version(stl::zwstring a_filename);
 }
+
+#ifdef __cpp_lib_format
+namespace std
+{
+    template<class CharT>
+    struct formatter<REL::Version, CharT> : formatter<std::string, CharT>
+	{
+        template<class FormatContext>
+        auto format(const REL::Version &a_version, FormatContext &a_ctx)
+		{
+            return formatter<std::string, CharT>::format(a_version.string(), a_ctx);
+        }
+    };
+}
+#endif

--- a/CommonLibSF/include/SFSE/Interfaces.h
+++ b/CommonLibSF/include/SFSE/Interfaces.h
@@ -129,8 +129,6 @@ namespace SFSE
 			kVersion = 1
 		};
 
-		constexpr void PluginVersion(std::uint32_t a_version) noexcept { pluginVersion = a_version; }
-
 		constexpr void PluginVersion(REL::Version a_version) noexcept { pluginVersion = a_version.pack(); }
 
 		[[nodiscard]] constexpr REL::Version GetPluginVersion() const noexcept { return REL::Version::unpack(pluginVersion); }

--- a/CommonLibSF/include/SFSE/Interfaces.h
+++ b/CommonLibSF/include/SFSE/Interfaces.h
@@ -133,7 +133,7 @@ namespace SFSE
 
 		constexpr void PluginVersion(REL::Version a_version) noexcept { pluginVersion = a_version.pack(); }
 
-		[[nodiscard]] constexpr std::uint32_t GetPluginVersion() const noexcept { return pluginVersion; }
+		[[nodiscard]] constexpr REL::Version GetPluginVersion() const noexcept { return REL::Version::unpack(pluginVersion); }
 
 		constexpr void PluginName(std::string_view a_plugin) noexcept { SetCharBuffer(a_plugin, std::span{ pluginName }); }
 
@@ -143,19 +143,22 @@ namespace SFSE
 
 		[[nodiscard]] constexpr std::string_view GetAuthorName() const noexcept { return std::string_view{ author }; }
 
-		constexpr void UsesSigScanning(bool a_value) noexcept { addressIndependence = SetOrClearBit(addressIndependence, 1 << 0, a_value); }
+		constexpr void UsesSigScanning(bool a_value) noexcept { SetOrClearBit(addressIndependence, 1 << 0, a_value); }
 
-		constexpr void UsesAddressLibrary(bool a_value) noexcept { addressIndependence = SetOrClearBit(addressIndependence, 1 << 1, a_value); }
+		constexpr void UsesAddressLibrary(bool a_value) noexcept { SetOrClearBit(addressIndependence, 1 << 1, a_value); }
 
-		constexpr void HasNoStructUse(bool a_value) noexcept { structureCompatibility = SetOrClearBit(structureCompatibility, 1 << 0, a_value); }
+		constexpr void HasNoStructUse(bool a_value) noexcept { SetOrClearBit(structureCompatibility, 1 << 0, a_value); }
 
-		constexpr void IsLayoutDependent(bool a_value) noexcept { structureCompatibility = SetOrClearBit(structureCompatibility, 1 << 1, a_value); }
+		constexpr void IsLayoutDependent(bool a_value) noexcept { SetOrClearBit(structureCompatibility, 1 << 1, a_value); }
 
 		constexpr void CompatibleVersions(std::initializer_list<REL::Version> a_versions) noexcept
 		{
 			// must be zero-terminated
 			assert(a_versions.size() < std::size(compatibleVersions) - 1);
-			std::ranges::transform(a_versions, std::begin(compatibleVersions), [](const REL::Version& a_version) noexcept { return a_version.pack(); });
+			std::ranges::transform(a_versions, std::begin(compatibleVersions), [](const REL::Version& a_version) noexcept
+			{
+				return a_version.pack();
+			});
 		}
 
 		constexpr void MinimumRequiredXSEVersion(REL::Version a_version) noexcept { xseMinimum = a_version.pack(); }
@@ -181,14 +184,12 @@ namespace SFSE
 			std::ranges::copy(a_src, a_dst.begin());
 		}
 
-		[[nodiscard]] static constexpr std::uint32_t SetOrClearBit(std::uint32_t a_data, std::uint32_t a_bit, bool a_set) noexcept
+		static constexpr void SetOrClearBit(std::uint32_t& a_data, std::uint32_t a_bit, bool a_set) noexcept
 		{
 			if (a_set)
 				a_data |= a_bit;
 			else
 				a_data &= ~a_bit;
-
-			return a_data;
 		}
 	};
 

--- a/CommonLibSF/src/REL/ID.cpp
+++ b/CommonLibSF/src/REL/ID.cpp
@@ -170,7 +170,7 @@ namespace REL
 		// sfse only loads plugins from { runtimeDirectory + "Data\\SFSE\\Plugins" }
 		auto file = std::filesystem::current_path();
 
-		file /= std::format("{}\\versionlib-{}", database::LookUpDir, version.string());
+		file /= std::format("{}\\versionlib-{}", database::LookUpDir, version.string("-"));
 
 		_platform = Platform::kUnknown;
 		for (auto& [vendor, registered] : database::VendorModule) {
@@ -223,7 +223,7 @@ namespace REL
 				// kDatabaseVersion, runtimeVersion, runtimePlatform
 				"CommonLibSF-Offsets-v{}-{}-{}",
 				std::to_underlying(database::kDatabaseVersion),
-				a_version.string(),
+				a_version.string("-"),
 				std::to_underlying(_platform)));
 
 			stl_assert(mapname.has_value(),


### PR DESCRIPTION
- set default separator to `.`
- simplify `SetOrClearBit`