### PR TITLE
chore: remove redundant code and unused includes

### DIFF
--- a/CommonLibSF/include/RE/B/BSFixedString.h
+++ b/CommonLibSF/include/RE/B/BSFixedString.h
@@ -193,7 +193,7 @@ namespace RE
 			static constexpr const value_type EMPTY[]{ 0 };
 
 			// members
-			BSStringPool::Entry* _data{ nullptr };  // 0
+			BSStringPool::Entry* _data{};  // 0
 		};
 
 		extern template class BSFixedString<char, false>;

--- a/CommonLibSF/include/RE/B/BSIntrusiveRefCounted.h
+++ b/CommonLibSF/include/RE/B/BSIntrusiveRefCounted.h
@@ -7,7 +7,7 @@ namespace RE
 	public:
 		SF_RTTI(BSIntrusiveRefCounted);
 
-		volatile mutable std::uint32_t refCount{ 0 };  // 00
+		volatile mutable std::uint32_t refCount{};  // 00
 		std::uint32_t                  unk04;          // 04
 	};
 	static_assert(sizeof(BSIntrusiveRefCounted) == 0x08);

--- a/CommonLibSF/include/RE/B/BSStringT.h
+++ b/CommonLibSF/include/RE/B/BSStringT.h
@@ -114,8 +114,8 @@ namespace RE
 			a_rhs._capacity = 0;
 		}
 
-		pointer   _data{ nullptr };  // ??
-		size_type _size{ 0 };        // ??
-		size_type _capacity{ 0 };    // ??
+		pointer   _data{};  // ??
+		size_type _size{};        // ??
+		size_type _capacity{};    // ??
 	};
 }

--- a/CommonLibSF/include/RE/F/FormTypes.h
+++ b/CommonLibSF/include/RE/F/FormTypes.h
@@ -231,7 +231,7 @@ namespace std
 {
 	[[nodiscard]] inline std::string to_string(RE::FormType a_formType)
 	{
-		return RE::FormTypeToString(a_formType);
+		return FormTypeToString(a_formType);
 	}
 }
 
@@ -250,7 +250,7 @@ namespace fmt
 		template <class FormatContext>
 		auto format(const RE::FormType& a_formType, FormatContext& a_ctx)
 		{
-			return fmt::format_to(a_ctx.out(), "{}", RE::FormTypeToString(a_formType));
+			return fmt::format_to(a_ctx.out(), "{}", FormTypeToString(a_formType));
 		}
 	};
 }
@@ -265,7 +265,7 @@ namespace std
 		template <class FormatContext>
 		auto format(RE::FormType a_formType, FormatContext& a_ctx)
 		{
-			return formatter<std::string_view, CharT>::format(RE::FormTypeToString(a_formType), a_ctx);
+			return formatter<std::string_view, CharT>::format(FormTypeToString(a_formType), a_ctx);
 		}
 	};
 }

--- a/CommonLibSF/include/RE/N/NativeFunctionBase.h
+++ b/CommonLibSF/include/RE/N/NativeFunctionBase.h
@@ -125,10 +125,10 @@ namespace RE
 				std::uint64_t _retType;                         // 28 TypeInfo
 				ParameterInfo _params;                          // 30
 				bool          _isStatic;                        // 40
-				bool          _isCallableFromTasklet{ false };  // 41
-				bool          _isLatent{ false };               // 42
+				bool          _isCallableFromTasklet{};  // 41
+				bool          _isLatent{};               // 42
 				std::uint8_t  _pad43;                           // 43
-				std::uint32_t _userFlags{ 0 };                  // 44
+				std::uint32_t _userFlags{};                  // 44
 				BSFixedString _docString;                       // 48
 			};
 			static_assert(sizeof(NativeFunctionBase) == 0x50);

--- a/CommonLibSF/include/RE/N/NiPoint3.h
+++ b/CommonLibSF/include/RE/N/NiPoint3.h
@@ -39,9 +39,9 @@ namespace RE
 		float                  Unitize();
 
 		// members
-		float x{ 0.0F };  // 0x0
-		float y{ 0.0F };  // 0x4
-		float z{ 0.0F };  // 0x8
+		float x{};  // 0x0
+		float y{};  // 0x4
+		float z{};  // 0x8
 	};
 	static_assert(sizeof(NiPoint3) == 0xC);
 

--- a/CommonLibSF/include/RE/N/NiSmartPointer.h
+++ b/CommonLibSF/include/RE/N/NiSmartPointer.h
@@ -136,7 +136,7 @@ namespace RE
 		}
 
 		// members
-		element_type* _ptr{ nullptr };  // 0
+		element_type* _ptr{};  // 0
 	};
 	static_assert(sizeof(NiPointer<void*>) == 0x8);
 

--- a/CommonLibSF/include/RE/RTTI.h
+++ b/CommonLibSF/include/RE/RTTI.h
@@ -53,7 +53,7 @@ namespace RE
 			[[nodiscard]] constexpr bool is_good() const noexcept { return _rva != 0; }
 
 			// members
-			std::uint32_t _rva{ 0 };  // 00
+			std::uint32_t _rva{};  // 00
 		};
 
 		static_assert(sizeof(RVA<void*>) == 0x4);

--- a/CommonLibSF/include/RE/S/ScaleformPtr.h
+++ b/CommonLibSF/include/RE/S/ScaleformPtr.h
@@ -174,7 +174,7 @@ namespace RE::Scaleform
 		}
 
 		// members
-		element_type* _ptr{ nullptr };  // 00
+		element_type* _ptr{};  // 00
 	};
 	static_assert(sizeof(Ptr<void*>) == 0x8);
 

--- a/CommonLibSF/include/RE/S/Script.h
+++ b/CommonLibSF/include/RE/S/Script.h
@@ -82,7 +82,7 @@ namespace RE
 		// members
 		const char*   paramName{ "" };    // 00
 		std::uint32_t paramType;          // 08 enumeration
-		bool          optional{ false };  // 0C
+		bool          optional{};  // 0C
 	};
 	static_assert(sizeof(SCRIPT_PARAMETER) == 0x10);
 

--- a/CommonLibSF/include/REL/ID.h
+++ b/CommonLibSF/include/REL/ID.h
@@ -57,8 +57,8 @@ namespace REL
 			void close();
 
 		private:
-			void* _mapping{ nullptr };
-			void* _view{ nullptr };
+			void* _mapping{};
+			void* _view{};
 		};
 
 		class Offset2ID
@@ -66,9 +66,9 @@ namespace REL
 		public:
 			using value_type = mapping_t;
 			using container_type = std::vector<value_type>;
-			using size_type = typename container_type::size_type;
-			using const_iterator = typename container_type::const_iterator;
-			using const_reverse_iterator = typename container_type::const_reverse_iterator;
+			using size_type = container_type::size_type;
+			using const_iterator = container_type::const_iterator;
+			using const_reverse_iterator = container_type::const_reverse_iterator;
 
 			template <class ExecutionPolicy>
 			explicit Offset2ID(ExecutionPolicy&& a_policy)
@@ -151,12 +151,12 @@ namespace REL
 
 			[[nodiscard]] std::size_t address_count() const noexcept
 			{
-				return static_cast<std::size_t>(_addressCount);
+				return _addressCount;
 			}
 
 			[[nodiscard]] std::uint64_t pointer_size() const noexcept
 			{
-				return static_cast<std::uint64_t>(_pointerSize);
+				return _pointerSize;
 			}
 
 			[[nodiscard]] std::string_view name() const noexcept
@@ -172,8 +172,8 @@ namespace REL
 		private:
 			char          _name[20]{};
 			Version       _version;
-			std::uint32_t _pointerSize{ 0 };
-			std::uint32_t _addressCount{ 0 };
+			std::uint32_t _pointerSize{};
+			std::uint32_t _addressCount{};
 		};
 	}
 
@@ -232,7 +232,7 @@ namespace REL
 		}
 
 		static IDDatabase              _instance;
-		inline static std::atomic_bool _initialized{ false };
+		inline static std::atomic_bool _initialized{};
 		inline static std::mutex       _initLock;
 		database::memory_map           _mmap;
 		std::span<database::mapping_t> _id2offset;
@@ -275,7 +275,7 @@ namespace REL
 			return Module::get().base();
 		}
 
-		std::uint64_t _id{ 0 };
+		std::uint64_t _id{};
 	};
 
 	template <class ExecutionPolicy>

--- a/CommonLibSF/include/REL/Module.h
+++ b/CommonLibSF/include/REL/Module.h
@@ -44,9 +44,9 @@ namespace REL
 	private:
 		friend class Module;
 
-		std::uintptr_t _proxyBase{ 0 };
-		std::uintptr_t _address{ 0 };
-		std::size_t    _size{ 0 };
+		std::uintptr_t _proxyBase{};
+		std::uintptr_t _address{};
+		std::size_t    _size{};
 	};
 
 	class Module
@@ -59,7 +59,7 @@ namespace REL
 		[[nodiscard]] constexpr auto base() const noexcept { return _base; }
 
 		template <typename T = void>
-		[[nodiscard]] constexpr auto* pointer() const noexcept
+		[[nodiscard]] constexpr auto pointer() const noexcept
 		{
 			return std::bit_cast<T*>(base());
 		}

--- a/CommonLibSF/include/REL/Offset.h
+++ b/CommonLibSF/include/REL/Offset.h
@@ -24,6 +24,6 @@ namespace REL
 		}
 
 	private:
-		std::ptrdiff_t _offset{ 0 };
+		std::ptrdiff_t _offset{};
 	};
 }

--- a/CommonLibSF/include/REL/Relocation.h
+++ b/CommonLibSF/include/REL/Relocation.h
@@ -3,7 +3,6 @@
 #include "REL/ID.h"
 #include "REL/Module.h"
 #include "REL/Offset.h"
-#include "REL/Version.h"
 
 #define REL_MAKE_MEMBER_FUNCTION_POD_TYPE_HELPER_IMPL(a_nopropQual, a_propQual, ...)              \
 	template <class R, class Cls, class... Args>                                                  \
@@ -153,14 +152,14 @@ namespace REL
 
 	inline void safe_write(const std::uintptr_t a_dst, const void* a_src, const std::size_t a_count)
 	{
-		std::uint32_t old{ 0 };
+		std::uint32_t old{};
 		auto          success = WinAPI::VirtualProtect(reinterpret_cast<void*>(a_dst), a_count, WinAPI::PAGE_EXECUTE_READWRITE, std::addressof(old));
-		if (success != 0) {
+		if (success) {
 			std::memcpy(reinterpret_cast<void*>(a_dst), a_src, a_count);
 			success = WinAPI::VirtualProtect(reinterpret_cast<void*>(a_dst), a_count, old, std::addressof(old));
 		}
 
-		assert(success != 0);
+		assert(success);
 	}
 
 	template <std::integral T>
@@ -177,14 +176,14 @@ namespace REL
 
 	inline void safe_fill(const std::uintptr_t a_dst, const std::uint8_t a_value, const std::size_t a_count)
 	{
-		std::uint32_t old{ 0 };
+		std::uint32_t old{};
 		auto          success = WinAPI::VirtualProtect(reinterpret_cast<void*>(a_dst), a_count, WinAPI::PAGE_EXECUTE_READWRITE, std::addressof(old));
-		if (success != 0) {
+		if (success) {
 			std::fill_n(reinterpret_cast<std::uint8_t*>(a_dst), a_count, a_value);
 			success = WinAPI::VirtualProtect(reinterpret_cast<void*>(a_dst), a_count, old, std::addressof(old));
 		}
 
-		assert(success != 0);
+		assert(success);
 	};
 
 	template <typename T = std::uintptr_t>
@@ -270,7 +269,7 @@ namespace REL
 	private:
 		[[nodiscard]] static std::uintptr_t base() { return Module::get().base(); }
 
-		std::uintptr_t _address{ 0 };
+		std::uintptr_t _address{};
 	};
 }
 

--- a/CommonLibSF/include/REL/Version.h
+++ b/CommonLibSF/include/REL/Version.h
@@ -79,7 +79,7 @@ namespace REL
 
 		[[nodiscard]] static constexpr Version unpack(const std::uint32_t a_packedVersion) noexcept
 		{
-			return REL::Version{
+			return Version{
 				static_cast<value_type>((a_packedVersion >> 24) & 0x0FF),
 				static_cast<value_type>((a_packedVersion >> 16) & 0x0FF),
 				static_cast<value_type>((a_packedVersion >> 4) & 0xFFF),
@@ -106,7 +106,7 @@ namespace REL
 		namespace detail
 		{
 			template <std::size_t Index, char C>
-			constexpr uint8_t read_version(std::array<typename REL::Version::value_type, 4>& result)
+			constexpr uint8_t read_version(std::array<Version::value_type, 4>& result)
 			{
 				static_assert(C >= '0' && C <= '9', "Invalid character in semantic version literal.");
 				static_assert(Index < 4, "Too many components in semantic version literal.");
@@ -116,7 +116,7 @@ namespace REL
 
 			template <std::size_t Index, char C, char... Rest>
 				requires(sizeof...(Rest) > 0)
-			constexpr uint8_t read_version(std::array<typename REL::Version::value_type, 4>& result)
+			constexpr uint8_t read_version(std::array<Version::value_type, 4>& result)
 			{
 				static_assert(C == '.' || (C >= '0' && C <= '9'), "Invalid character in semantic version literal.");
 				static_assert(Index < 4, "Too many components in semantic version literal.");
@@ -132,14 +132,14 @@ namespace REL
 		}
 
 		template <char... C>
-		[[nodiscard]] constexpr REL::Version operator""_v() noexcept
+		[[nodiscard]] constexpr Version operator""_v() noexcept
 		{
-			std::array<typename REL::Version::value_type, 4> result{ 0, 0, 0, 0 };
+			std::array<Version::value_type, 4> result{ 0, 0, 0, 0 };
 			detail::read_version<0, C...>(result);
-			return REL::Version(result);
+			return Version(result);
 		}
 
-		[[nodiscard]] constexpr REL::Version operator""_v(const char* str, const std::size_t len)
+		[[nodiscard]] constexpr Version operator""_v(const char* str, const std::size_t len)
 		{
 			return Version(std::string_view(str, len));
 		}

--- a/CommonLibSF/include/SFSE/API.h
+++ b/CommonLibSF/include/SFSE/API.h
@@ -3,7 +3,6 @@
 #include "SFSE/Impl/Stubs.h"
 #include "SFSE/Interfaces.h"
 #include "SFSE/Trampoline.h"
-#include "SFSE/Version.h"
 
 #define SFSEAPI __cdecl
 

--- a/CommonLibSF/include/SFSE/IAT.h
+++ b/CommonLibSF/include/SFSE/IAT.h
@@ -8,7 +8,7 @@ namespace SFSE
 	[[nodiscard]] void* GetIATPtr(std::string_view a_dll, std::string_view a_function);
 
 	template <class T>
-	[[nodiscard]] inline T* GetIATPtr(std::string_view a_dll, std::string_view a_function)
+	[[nodiscard]] T* GetIATPtr(std::string_view a_dll, std::string_view a_function)
 	{
 		return static_cast<T*>(GetIATPtr(std::move(a_dll), std::move(a_function)));
 	}
@@ -16,7 +16,7 @@ namespace SFSE
 	[[nodiscard]] void* GetIATPtr(void* a_module, std::string_view a_dll, std::string_view a_function);
 
 	template <class T>
-	[[nodiscard]] inline T* GetIATPtr(void* a_module, std::string_view a_dll, std::string_view a_function)
+	[[nodiscard]] T* GetIATPtr(void* a_module, std::string_view a_dll, std::string_view a_function)
 	{
 		return static_cast<T*>(GetIATPtr(a_module, std::move(a_dll), std::move(a_function)));
 	}
@@ -24,7 +24,7 @@ namespace SFSE
 	std::uintptr_t PatchIAT(std::uintptr_t a_newFunc, std::string_view a_dll, std::string_view a_function);
 
 	template <class F>
-	inline std::uintptr_t PatchIAT(F a_newFunc, const std::string_view a_dll, const std::string_view a_function)
+	std::uintptr_t PatchIAT(F a_newFunc, const std::string_view a_dll, const std::string_view a_function)
 	{
 		return PatchIAT(stl::unrestricted_cast<std::uintptr_t>(a_newFunc), a_dll, a_function);
 	}

--- a/CommonLibSF/include/SFSE/Impl/PCH.h
+++ b/CommonLibSF/include/SFSE/Impl/PCH.h
@@ -389,11 +389,11 @@ namespace SFSE
 			}
 
 		private:
-			underlying_type _impl{ 0 };
+			underlying_type _impl{};
 		};
 
 		template <class... Args>
-		enumeration(Args...) -> enumeration<std::common_type_t<Args...>, std::underlying_type_t<std::common_type_t<Args...>>>;
+		enumeration(Args...) -> enumeration<std::common_type_t<Args...>>;
 	}
 }
 
@@ -583,12 +583,12 @@ namespace SFSE
 		void memzero(volatile T* a_ptr, const std::size_t a_size = sizeof(T))
 		{
 			const auto     begin = reinterpret_cast<volatile char*>(a_ptr);
-			constexpr char val{ 0 };
+			constexpr char val{};
 			std::fill_n(begin, a_size, val);
 		}
 
 		template <class... Args>
-		[[nodiscard]] inline auto pun_bits(Args... a_args)
+		[[nodiscard]] auto pun_bits(Args... a_args)
 			requires(std::same_as<std::remove_cv_t<Args>, bool> && ...)
 		{
 			constexpr auto ARGC = sizeof...(Args);
@@ -675,9 +675,8 @@ namespace SFSE
 				if (result && result != buf.size()) {
 					std::filesystem::path p(buf.begin(), buf.begin() + result);
 					return p.filename().native();
-				} else {
-					return L""s;
 				}
+				return L""s;
 			}();
 
 			spdlog::log(spdlog::source_loc{ a_loc.file_name(), static_cast<int>(a_loc.line()), a_loc.function_name() }, spdlog::level::critical, a_msg);

--- a/CommonLibSF/include/SFSE/Interfaces.h
+++ b/CommonLibSF/include/SFSE/Interfaces.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "SFSE/Impl/Stubs.h"
-#include "SFSE/Version.h"
 
 namespace RE
 {

--- a/CommonLibSF/include/SFSE/Trampoline.h
+++ b/CommonLibSF/include/SFSE/Trampoline.h
@@ -84,7 +84,7 @@ namespace SFSE
 		{
 			const auto trampoline = static_cast<std::byte*>(a_trampoline);
 			if (trampoline) {
-				constexpr auto INT3 = static_cast<int>(0xCC);
+				constexpr auto INT3 = 0xCC;
 				std::memset(trampoline, INT3, a_size);
 			}
 
@@ -241,8 +241,8 @@ namespace SFSE
 
 			mem->jmp = static_cast<std::uint8_t>(0xFF);
 			mem->modrm = static_cast<std::uint8_t>(0x25);
-			mem->disp = static_cast<std::int32_t>(0);
-			mem->addr = static_cast<std::uint64_t>(a_dst);
+			mem->disp = 0;
+			mem->addr = a_dst;
 		}
 
 		void write_6branch(const std::uintptr_t a_src, std::uintptr_t a_dst, const std::uint8_t a_modrm)
@@ -263,7 +263,7 @@ namespace SFSE
 			static_assert(sizeof(Assembly) == 0x6);
 #pragma pack(pop)
 
-			std::uintptr_t* mem = nullptr;
+			std::uintptr_t* mem;
 			if (const auto it = _6branches.find(a_dst); it != _6branches.end()) {
 				mem = reinterpret_cast<std::uintptr_t*>(it->second);
 			} else {
@@ -348,8 +348,8 @@ namespace SFSE
 		std::map<std::uintptr_t, std::byte*> _6branches;
 		std::string                          _name{ "Default Trampoline"sv };
 		deleter_type                         _deleter;
-		std::byte*                           _data{ nullptr };
-		std::size_t                          _capacity{ 0 };
-		std::size_t                          _size{ 0 };
+		std::byte*                           _data{};
+		std::size_t                          _capacity{};
+		std::size_t                          _size{};
 	};
 }

--- a/CommonLibSF/src/RE/N/NiPoint3.cpp
+++ b/CommonLibSF/src/RE/N/NiPoint3.cpp
@@ -147,7 +147,8 @@ namespace RE
 		auto length = Length();
 		if (length == 1.f) {
 			return length;
-		} else if (length > FLT_EPSILON) {
+		}
+		if (length > FLT_EPSILON) {
 			operator/=(length);
 		} else {
 			x = 0.0;

--- a/CommonLibSF/src/REL/ID.cpp
+++ b/CommonLibSF/src/REL/ID.cpp
@@ -4,8 +4,8 @@ namespace REL
 {
 	namespace database
 	{
-		constexpr auto                                                             LookUpDir = "Data\\SFSE\\Plugins"sv;
-		constexpr std::array<std::pair<std::string_view, IDDatabase::Platform>, 2> VendorModule{
+		constexpr auto       LookUpDir = "Data\\SFSE\\Plugins"sv;
+		constexpr std::array VendorModule{
 			std::make_pair("steam_api64"sv, IDDatabase::Platform::kSteam),
 			std::make_pair("XGameRuntime"sv, IDDatabase::Platform::kMsStore),
 		};
@@ -32,7 +32,7 @@ namespace REL
 		{
 			close();
 
-			WinAPI::ULARGE_INTEGER bytes{};
+			WinAPI::ULARGE_INTEGER bytes;
 			bytes.value = a_size;
 
 			_mapping = WinAPI::OpenFileMapping(
@@ -64,7 +64,7 @@ namespace REL
 		{
 			close();
 
-			WinAPI::ULARGE_INTEGER bytes{};
+			WinAPI::ULARGE_INTEGER bytes;
 			bytes.value = a_size;
 
 			_mapping = WinAPI::OpenFileMapping(
@@ -103,7 +103,7 @@ namespace REL
 		void memory_map::close()
 		{
 			if (_view) {
-				(void)WinAPI::UnmapViewOfFile(static_cast<const void*>(_view));
+				(void)WinAPI::UnmapViewOfFile(_view);
 				_view = nullptr;
 			}
 
@@ -161,7 +161,7 @@ namespace REL
 			"library for this version of the game, and thus does not support it."sv,
 			a_id, std::to_underlying(database::kDatabaseVersion));
 
-		return static_cast<std::size_t>(it->offset);
+		return it->offset;
 	}
 
 	std::wstring IDDatabase::addresslib_filename()
@@ -229,7 +229,7 @@ namespace REL
 			stl_assert(mapname.has_value(),
 				"Failed to generate memory map name.");
 
-			const auto byteSize = static_cast<std::size_t>(header.address_count()) * sizeof(database::mapping_t);
+			const auto byteSize = header.address_count() * sizeof(database::mapping_t);
 			if (_mmap.open(mapname.value(), byteSize)) {
 				_id2offset = { static_cast<database::mapping_t*>(_mmap.data()), header.address_count() };
 			} else if (_mmap.create(mapname.value(), byteSize)) {
@@ -259,7 +259,6 @@ namespace REL
 					a_version.string(),
 					database::VendorModule[std::to_underlying(_platform)].first),
 				a_failOnError);
-			return false;
 		}
 		return true;
 	}

--- a/CommonLibSF/src/REL/Module.cpp
+++ b/CommonLibSF/src/REL/Module.cpp
@@ -10,7 +10,7 @@ namespace REL
 
 		const auto  dosHeader = reinterpret_cast<const WinAPI::IMAGE_DOS_HEADER*>(_base);
 		const auto  ntHeader = stl::adjust_pointer<WinAPI::IMAGE_NT_HEADERS64>(dosHeader, dosHeader->lfanew);
-		const auto* sections = WinAPI::IMAGE_FIRST_SECTION(ntHeader);
+		const auto sections = IMAGE_FIRST_SECTION(ntHeader);
 		const auto  size = std::min<std::size_t>(ntHeader->fileHeader.sectionCount, _segments.size());
 
 		for (std::size_t i = 0; i < size; ++i) {

--- a/CommonLibSF/src/REL/Version.cpp
+++ b/CommonLibSF/src/REL/Version.cpp
@@ -5,7 +5,7 @@ namespace REL
 	constexpr Version::Version(const std::string_view a_version)
 	{
 		std::array<value_type, 4> powers{ 1, 1, 1, 1 };
-		std::size_t               position = 0;
+		std::size_t               position{};
 		for (std::size_t i = 0; i < a_version.size(); ++i) {
 			if (a_version[i] == '.') {
 				if (++position == powers.size()) {
@@ -30,18 +30,18 @@ namespace REL
 
 	[[nodiscard]] std::optional<Version> get_file_version(const stl::zwstring a_filename)
 	{
-		std::uint32_t     dummy{ 0 };
+		std::uint32_t     dummy{};
 		std::vector<char> buf(WinAPI::GetFileVersionInfoSize(a_filename.data(), std::addressof(dummy)));
 		if (buf.empty()) {
 			return std::nullopt;
 		}
 
-		if (!WinAPI::GetFileVersionInfo(a_filename.data(), 0, static_cast<std::uint32_t>(buf.size()), buf.data())) {
+		if (!WinAPI::GetFileVersionInfo(a_filename.data(), 0, buf.size(), buf.data())) {
 			return std::nullopt;
 		}
 
-		void*         verBuf{ nullptr };
-		std::uint32_t verLen{ 0 };
+		void*         verBuf{};
+		std::uint32_t verLen{};
 		if (!WinAPI::VerQueryValue(buf.data(), L"\\StringFileInfo\\040904B0\\ProductVersion", std::addressof(verBuf), std::addressof(verLen))) {
 			return std::nullopt;
 		}

--- a/CommonLibSF/src/SFSE/API.cpp
+++ b/CommonLibSF/src/SFSE/API.cpp
@@ -16,13 +16,13 @@ namespace SFSE
 
 			PluginHandle pluginHandle{ static_cast<PluginHandle>(-1) };
 
-			TrampolineInterface* trampolineInterface{ nullptr };
-			MessagingInterface*  messagingInterface{ nullptr };
-			MenuInterface*       menuInterface{ nullptr };
+			TrampolineInterface* trampolineInterface{};
+			MessagingInterface*  messagingInterface{};
+			MenuInterface*       menuInterface{};
 
 			std::mutex                         apiLock;
 			std::vector<std::function<void()>> apiInitRegs;
-			bool                               apiInit{ false };
+			bool                               apiInit{};
 
 		private:
 			APIStorage() noexcept = default;

--- a/CommonLibSF/src/SFSE/InputMap.cpp
+++ b/CommonLibSF/src/SFSE/InputMap.cpp
@@ -91,11 +91,11 @@ namespace SFSE
 	{
 		if (a_keyCode >= kMacro_MouseButtonOffset && a_keyCode < kMacro_GamepadOffset) {
 			return GetMouseButtonName(a_keyCode);
-		} else if (a_keyCode >= kMacro_GamepadOffset && a_keyCode < kMaxMacros) {
-			return GetGamepadButtonName(a_keyCode);
-		} else {
-			return GetKeyboardKeyName(a_keyCode);
 		}
+		if (a_keyCode >= kMacro_GamepadOffset && a_keyCode < kMaxMacros) {
+			return GetGamepadButtonName(a_keyCode);
+		}
+		return GetKeyboardKeyName(a_keyCode);
 	}
 
 	std::string InputMap::GetKeyboardKeyName(const std::uint32_t a_keyCode)

--- a/CommonLibSF/src/SFSE/Logger.cpp
+++ b/CommonLibSF/src/SFSE/Logger.cpp
@@ -10,7 +10,7 @@ namespace SFSE
 	{
 		std::optional<std::filesystem::path> log_directory()
 		{
-			wchar_t*                                                           buffer{ nullptr };
+			wchar_t*                                                           buffer{};
 			const auto                                                         result = WinAPI::SHGetKnownFolderPath(WinAPI::FOLDERID_DOCUMENTS, WinAPI::KF_FLAG_DEFAULT, nullptr, std::addressof(buffer));
 			const std::unique_ptr<wchar_t[], decltype(&WinAPI::CoTaskMemFree)> knownPath(buffer, WinAPI::CoTaskMemFree);
 			if (!knownPath || result != 0) {

--- a/CommonLibSF/src/SFSE/Trampoline.cpp
+++ b/CommonLibSF/src/SFSE/Trampoline.cpp
@@ -32,16 +32,15 @@ namespace SFSE
 		constexpr std::uintptr_t maxAddr = std::numeric_limits<std::uintptr_t>::max();
 
 		WinAPI::SYSTEM_INFO si;
-		WinAPI::GetSystemInfo(&si);
+		GetSystemInfo(&si);
 		const std::uint32_t granularity = si.allocationGranularity;
 
 		std::uintptr_t       min = a_address >= minRange ? detail::roundup(a_address - minRange, granularity) : 0;
 		const std::uintptr_t max = a_address < (maxAddr - minRange) ? detail::rounddown(a_address + minRange, granularity) : maxAddr;
-		std::uintptr_t       addr;
 
 		WinAPI::MEMORY_BASIC_INFORMATION mbi;
 		do {
-			if (!WinAPI::VirtualQuery(reinterpret_cast<void*>(min), std::addressof(mbi), sizeof(mbi))) {
+			if (!VirtualQuery(reinterpret_cast<void*>(min), std::addressof(mbi), sizeof(mbi))) {
 				log::error("VirtualQuery failed with code: 0x{:08X}"sv, WinAPI::GetLastError());
 				return nullptr;
 			}
@@ -50,7 +49,7 @@ namespace SFSE
 			min = baseAddr + mbi.regionSize;
 
 			if (mbi.state == WinAPI::MEM_FREE) {
-				addr = detail::roundup(baseAddr, granularity);
+				std::uintptr_t addr = detail::roundup(baseAddr, granularity);
 
 				// if rounding didn't advance us into the next region and the region is the required size
 				if (addr < min && (min - addr) >= a_size) {


### PR DESCRIPTION
- Remove unused includes
- Remove redundant code:
  - zero/null initialization
  - instances of `typename` keyword
  - qualifiers
  - `static_cast`s
  - template arguments
  - instances of `else` keyword