### PR TITLE
chore: add xmake ci

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -2,7 +2,7 @@ name: Main CI [CMake]
 
 on:
   pull_request:
-    branches: [main, feature/*]
+    branches: [main, feature/*, fix/*]
     paths:
       - "CommonLibSF/**"
   workflow_dispatch:

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -1,4 +1,4 @@
-name: Main CI
+name: Main CI [CMake]
 
 on:
   pull_request:

--- a/.github/workflows/main_ci_xmake.yml
+++ b/.github/workflows/main_ci_xmake.yml
@@ -1,0 +1,26 @@
+name: Main CI [XMake]
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    stategy:
+      fail-fast: false
+      matrix:
+        mode: [release]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup XMake
+        uses: xmake-io/github-action-setup-xmake@latest
+        with:
+          xmake-version: '2.8.2'
+
+      - name: Configure
+        run: xmake config --mode=${{ matrix.mode }}
+
+      - name: Build
+        run: xmake build -y -vD

--- a/.github/workflows/main_ci_xmake.yml
+++ b/.github/workflows/main_ci_xmake.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup XMake
-        uses: xmake-io/github-action-setup-xmake@latest
+        uses: xmake-io/github-action-setup-xmake@v1.0.13
         with:
           xmake-version: '2.8.2'
 

--- a/.github/workflows/main_ci_xmake.yml
+++ b/.github/workflows/main_ci_xmake.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
     runs-on: windows-latest
-    stategy:
+    strategy:
       fail-fast: false
       matrix:
         mode: [release]

--- a/.github/workflows/main_ci_xmake.yml
+++ b/.github/workflows/main_ci_xmake.yml
@@ -20,7 +20,7 @@ jobs:
           xmake-version: '2.8.2'
 
       - name: Configure
-        run: xmake config --mode=${{ matrix.mode }}
+        run: xmake config -y --mode=${{ matrix.mode }}
 
       - name: Build
         run: xmake build -y -vD

--- a/.github/workflows/main_ci_xmake.yml
+++ b/.github/workflows/main_ci_xmake.yml
@@ -25,7 +25,7 @@ jobs:
           xmake-version: '2.8.2'
 
       - name: Configure
-        run: xmake config -y --mode=${{ matrix.mode }}
+        run: xmake config -y --mode=${{ matrix.mode }} --vs_toolset=14.37
 
       - name: Build
         run: xmake build -y -vD

--- a/.github/workflows/main_ci_xmake.yml
+++ b/.github/workflows/main_ci_xmake.yml
@@ -1,6 +1,11 @@
 name: Main CI [XMake]
 
-on: [push]
+on:
+  pull_request:
+    branches: [main, feature/*, fix/*]
+    paths:
+      - "CommonLibSF/**"
+      - "xmake.lua"
 
 jobs:
   build:

--- a/CommonLibSF/include/SFSE/Impl/PCH.h
+++ b/CommonLibSF/include/SFSE/Impl/PCH.h
@@ -41,7 +41,7 @@
 #include <climits>
 #include <cstdint>
 #include <limits>
-#include <stdfloat>
+//#include <stdfloat>
 
 // Error handling
 #include <cassert>

--- a/CommonLibSF/include/SFSE/Impl/PCH.h
+++ b/CommonLibSF/include/SFSE/Impl/PCH.h
@@ -41,7 +41,7 @@
 #include <climits>
 #include <cstdint>
 #include <limits>
-//#include <stdfloat>
+#include <stdfloat>
 
 // Error handling
 #include <cassert>
@@ -109,7 +109,7 @@
 #include <iostream>
 #include <istream>
 #include <ostream>
-//#include <print>
+#include <print>
 #include <spanstream>
 #include <sstream>
 #include <streambuf>

--- a/CommonLibSF/include/SFSE/Impl/PCH.h
+++ b/CommonLibSF/include/SFSE/Impl/PCH.h
@@ -109,7 +109,7 @@
 #include <iostream>
 #include <istream>
 #include <ostream>
-#include <print>
+//#include <print>
 #include <spanstream>
 #include <sstream>
 #include <streambuf>


### PR DESCRIPTION
I had to comment out two includes (`stdfloat` and `print`) due to CI not using a newer version of the toolset (14.37) which includes these features.
https://en.cppreference.com/w/cpp/compiler_support/23