### PR TITLE
refactor: stuff

### DIFF
--- a/CommonLibSF/include/REL/ID.h
+++ b/CommonLibSF/include/REL/ID.h
@@ -78,7 +78,7 @@ namespace REL
 				Offset2ID(std::execution::sequenced_policy{})
 			{}
 
-			[[nodiscard]] constexpr std::uint64_t operator()(std::size_t a_offset) const;
+			[[nodiscard]] std::uint64_t operator()(std::size_t a_offset) const;
 
 			[[nodiscard]] constexpr const_iterator begin() const noexcept { return _offset2id.begin(); }
 

--- a/CommonLibSF/include/REL/Version.h
+++ b/CommonLibSF/include/REL/Version.h
@@ -149,16 +149,13 @@ namespace REL
 }
 
 #ifdef __cpp_lib_format
-namespace std
+template <class CharT>
+struct std::formatter<REL::Version, CharT> : formatter<std::string, CharT>
 {
-	template <class CharT>
-	struct formatter<REL::Version, CharT> : formatter<std::string, CharT>
+	template <class FormatContext>
+	constexpr auto format(const REL::Version a_version, FormatContext& a_ctx) const
 	{
-		template <class FormatContext>
-		constexpr auto format(const REL::Version a_version, FormatContext& a_ctx) const
-		{
-			return formatter<std::string, CharT>::format(a_version.string(), a_ctx);
-		}
-	};
-}
+		return formatter<std::string, CharT>::format(a_version.string(), a_ctx);
+	}
+};
 #endif

--- a/CommonLibSF/include/SFSE/IAT.h
+++ b/CommonLibSF/include/SFSE/IAT.h
@@ -8,17 +8,17 @@ namespace SFSE
 	[[nodiscard]] constexpr void* GetIATPtr(std::string_view a_dll, std::string_view a_function);
 
 	template <class T>
-	[[nodiscard]] constexpr T* GetIATPtr(std::string_view a_dll, std::string_view a_function)
+	[[nodiscard]] constexpr T* GetIATPtr(const std::string_view a_dll, const std::string_view a_function)
 	{
-		return static_cast<T*>(GetIATPtr(std::move(a_dll), std::move(a_function)));
+		return static_cast<T*>(GetIATPtr(a_dll, a_function));
 	}
 
 	[[nodiscard]] constexpr void* GetIATPtr(void* a_module, std::string_view a_dll, std::string_view a_function);
 
 	template <class T>
-	[[nodiscard]] T* GetIATPtr(void* a_module, std::string_view a_dll, std::string_view a_function)
+	[[nodiscard]] T* GetIATPtr(void* a_module, const std::string_view a_dll, const std::string_view a_function)
 	{
-		return static_cast<T*>(GetIATPtr(a_module, std::move(a_dll), std::move(a_function)));
+		return static_cast<T*>(GetIATPtr(a_module, a_dll, a_function));
 	}
 
 	std::uintptr_t PatchIAT(std::uintptr_t a_newFunc, std::string_view a_dll, std::string_view a_function);

--- a/CommonLibSF/include/SFSE/Impl/PCH.h
+++ b/CommonLibSF/include/SFSE/Impl/PCH.h
@@ -222,9 +222,9 @@ namespace SFSE
 
 				[[nodiscard]] consteval const_reference front() const noexcept { return (*this)[0]; }
 
-				[[nodiscard]] consteval size_type length() const noexcept { return N; }
+				[[nodiscard]] static consteval size_type length() noexcept { return N; }
 
-				[[nodiscard]] consteval size_type size() const noexcept { return length(); }
+				[[nodiscard]] static consteval size_type size() noexcept { return length(); }
 
 				template <std::size_t POS = 0, std::size_t COUNT = npos>
 				[[nodiscard]] consteval auto substr() const noexcept
@@ -335,6 +335,7 @@ namespace SFSE
 			constexpr enumeration& operator=(enumeration<Enum, U2> a_rhs) noexcept
 			{
 				_impl = static_cast<underlying_type>(a_rhs.get());
+				return *this;
 			}
 
 			constexpr enumeration& operator=(enum_type a_value) noexcept
@@ -475,261 +476,258 @@ namespace SFSE
 		return tmp;                                                                                               \
 	}
 
-namespace SFSE
+namespace SFSE::stl
 {
-	namespace stl
+	template <class E, class U>
+	[[nodiscard]] constexpr auto operator~(enumeration<E, U> a_enum) noexcept -> enumeration<E, U>
 	{
-		template <class E, class U>
-		[[nodiscard]] constexpr auto operator~(enumeration<E, U> a_enum) noexcept -> enumeration<E, U>
-		{
-			return static_cast<E>(~static_cast<U>(a_enum.get()));
+		return static_cast<E>(~static_cast<U>(a_enum.get()));
+	}
+
+	SFSE_MAKE_LOGICAL_OP(==, bool);
+	SFSE_MAKE_LOGICAL_OP(<=>, std::strong_ordering);
+
+	SFSE_MAKE_ARITHMETIC_OP(<<);
+	SFSE_MAKE_ENUMERATION_OP(<<);
+	SFSE_MAKE_ARITHMETIC_OP(>>);
+	SFSE_MAKE_ENUMERATION_OP(>>);
+
+	SFSE_MAKE_ENUMERATION_OP(|);
+	SFSE_MAKE_ENUMERATION_OP(&);
+	SFSE_MAKE_ENUMERATION_OP(^);
+
+	SFSE_MAKE_ENUMERATION_OP(+);
+	SFSE_MAKE_ENUMERATION_OP(-);
+
+	SFSE_MAKE_INCREMENTER_OP(+);  // ++
+	SFSE_MAKE_INCREMENTER_OP(-);  // --
+
+	template <class T>
+	class atomic_ref : public std::atomic_ref<T>
+	{
+	private:
+		using super = std::atomic_ref<T>;
+
+	public:
+		using value_type = typename super::value_type;
+
+		explicit atomic_ref(volatile T& a_obj) noexcept(std::is_nothrow_constructible_v<super, value_type&>) :
+			super(const_cast<value_type&>(a_obj)) {}
+
+		using super::super;
+		using super::operator=;
+	};
+
+	template <class T>
+	atomic_ref(volatile T&) -> atomic_ref<T>;
+
+	template class atomic_ref<std::int8_t>;
+	template class atomic_ref<std::uint8_t>;
+	template class atomic_ref<std::int16_t>;
+	template class atomic_ref<std::uint16_t>;
+	template class atomic_ref<std::int32_t>;
+	template class atomic_ref<std::uint32_t>;
+	template class atomic_ref<std::int64_t>;
+	template class atomic_ref<std::uint64_t>;
+
+	static_assert(atomic_ref<std::int8_t>::is_always_lock_free);
+	static_assert(atomic_ref<std::uint8_t>::is_always_lock_free);
+	static_assert(atomic_ref<std::int16_t>::is_always_lock_free);
+	static_assert(atomic_ref<std::uint16_t>::is_always_lock_free);
+	static_assert(atomic_ref<std::int32_t>::is_always_lock_free);
+	static_assert(atomic_ref<std::uint32_t>::is_always_lock_free);
+	static_assert(atomic_ref<std::int64_t>::is_always_lock_free);
+	static_assert(atomic_ref<std::uint64_t>::is_always_lock_free);
+
+	template <class T>
+	struct ssizeof
+	{
+		[[nodiscard]] constexpr operator std::ptrdiff_t() const noexcept { return value; }
+
+		[[nodiscard]] constexpr std::ptrdiff_t operator()() const noexcept { return value; }
+
+		static constexpr auto value = static_cast<std::ptrdiff_t>(sizeof(T));
+	};
+
+	template <class T>
+	inline constexpr auto ssizeof_v = ssizeof<T>::value;
+
+	template <class T, class U>
+	[[nodiscard]] auto adjust_pointer(U* a_ptr, const std::ptrdiff_t a_adjust) noexcept
+	{
+		auto addr = a_ptr ? reinterpret_cast<std::uintptr_t>(a_ptr) + a_adjust : 0;
+		if constexpr (std::is_const_v<U> && std::is_volatile_v<U>) {
+			return reinterpret_cast<std::add_cv_t<T>*>(addr);
+		} else if constexpr (std::is_const_v<U>) {
+			return reinterpret_cast<std::add_const_t<T>*>(addr);
+		} else if constexpr (std::is_volatile_v<U>) {
+			return reinterpret_cast<std::add_volatile_t<T>*>(addr);
+		} else {
+			return reinterpret_cast<T*>(addr);
 		}
+	}
 
-		SFSE_MAKE_LOGICAL_OP(==, bool);
-		SFSE_MAKE_LOGICAL_OP(<=>, std::strong_ordering);
+	template <class T>
+	bool emplace_vtable(T* a_ptr)
+	{
+		auto address = T::VTABLE[0].address();
+		if (!address) {
+			return false;
+		}
+		reinterpret_cast<std::uintptr_t*>(a_ptr)[0] = address;
+		return true;
+	}
 
-		SFSE_MAKE_ARITHMETIC_OP(<<);
-		SFSE_MAKE_ENUMERATION_OP(<<);
-		SFSE_MAKE_ARITHMETIC_OP(>>);
-		SFSE_MAKE_ENUMERATION_OP(>>);
+	template <class T>
+	void memzero(volatile T* a_ptr, const std::size_t a_size = sizeof(T))
+	{
+		const auto     begin = reinterpret_cast<volatile char*>(a_ptr);
+		constexpr char val{};
+		std::fill_n(begin, a_size, val);
+	}
 
-		SFSE_MAKE_ENUMERATION_OP(|);
-		SFSE_MAKE_ENUMERATION_OP(&);
-		SFSE_MAKE_ENUMERATION_OP(^);
+	template <class... Args>
+	[[nodiscard]] auto pun_bits(Args... a_args)
+		requires(std::same_as<std::remove_cv_t<Args>, bool> && ...)
+	{
+		constexpr auto ARGC = sizeof...(Args);
 
-		SFSE_MAKE_ENUMERATION_OP(+);
-		SFSE_MAKE_ENUMERATION_OP(-);
+		std::bitset<ARGC> bits;
+		std::size_t       i = 0;
+		((bits[i++] = a_args), ...);
 
-		SFSE_MAKE_INCREMENTER_OP(+);  // ++
-		SFSE_MAKE_INCREMENTER_OP(-);  // --
+		if constexpr (ARGC <= std::numeric_limits<unsigned long>::digits) {
+			return bits.to_ulong();
+		} else if constexpr (ARGC <= std::numeric_limits<unsigned long long>::digits) {
+			return bits.to_ullong();
+		} else {
+			static_assert(false && sizeof...(Args));
+		}
+	}
 
-		template <class T>
-		class atomic_ref : public std::atomic_ref<T>
-		{
-		private:
-			using super = std::atomic_ref<T>;
-
-		public:
-			using value_type = typename super::value_type;
-
-			explicit atomic_ref(volatile T& a_obj) noexcept(std::is_nothrow_constructible_v<super, value_type&>) :
-				super(const_cast<value_type&>(a_obj)) {}
-
-			using super::super;
-			using super::operator=;
+	[[nodiscard]] inline auto utf8_to_utf16(const std::string_view a_in) noexcept -> std::optional<std::wstring>
+	{
+		const auto cvt = [&](wchar_t* a_dst, const std::size_t a_length) {
+			return WinAPI::MultiByteToWideChar(
+				WinAPI::CP_UTF8, 0, a_in.data(), static_cast<int>(a_in.length()), a_dst, static_cast<int>(a_length));
 		};
 
-		template <class T>
-		atomic_ref(volatile T&) -> atomic_ref<T>;
+		const auto len = cvt(nullptr, 0);
+		if (len == 0) {
+			return std::nullopt;
+		}
 
-		template class atomic_ref<std::int8_t>;
-		template class atomic_ref<std::uint8_t>;
-		template class atomic_ref<std::int16_t>;
-		template class atomic_ref<std::uint16_t>;
-		template class atomic_ref<std::int32_t>;
-		template class atomic_ref<std::uint32_t>;
-		template class atomic_ref<std::int64_t>;
-		template class atomic_ref<std::uint64_t>;
+		std::wstring out(len, '\0');
+		if (cvt(out.data(), out.length()) == 0) {
+			return std::nullopt;
+		}
 
-		static_assert(atomic_ref<std::int8_t>::is_always_lock_free);
-		static_assert(atomic_ref<std::uint8_t>::is_always_lock_free);
-		static_assert(atomic_ref<std::int16_t>::is_always_lock_free);
-		static_assert(atomic_ref<std::uint16_t>::is_always_lock_free);
-		static_assert(atomic_ref<std::int32_t>::is_always_lock_free);
-		static_assert(atomic_ref<std::uint32_t>::is_always_lock_free);
-		static_assert(atomic_ref<std::int64_t>::is_always_lock_free);
-		static_assert(atomic_ref<std::uint64_t>::is_always_lock_free);
+		return out;
+	}
 
-		template <class T>
-		struct ssizeof
-		{
-			[[nodiscard]] constexpr operator std::ptrdiff_t() const noexcept { return value; }
-
-			[[nodiscard]] constexpr std::ptrdiff_t operator()() const noexcept { return value; }
-
-			static constexpr auto value = static_cast<std::ptrdiff_t>(sizeof(T));
+	[[nodiscard]] inline auto utf16_to_utf8(const std::wstring_view a_in) noexcept -> std::optional<std::string>
+	{
+		const auto cvt = [&](char* a_dst, const std::size_t a_length) {
+			return WinAPI::WideCharToMultiByte(
+				WinAPI::CP_UTF8, 0, a_in.data(), static_cast<int>(a_in.length()), a_dst, static_cast<int>(a_length), nullptr, nullptr);
 		};
 
-		template <class T>
-		inline constexpr auto ssizeof_v = ssizeof<T>::value;
+		const auto len = cvt(nullptr, 0);
+		if (len == 0) {
+			return std::nullopt;
+		}
 
-		template <class T, class U>
-		[[nodiscard]] auto adjust_pointer(U* a_ptr, const std::ptrdiff_t a_adjust) noexcept
-		{
-			auto addr = a_ptr ? reinterpret_cast<std::uintptr_t>(a_ptr) + a_adjust : 0;
-			if constexpr (std::is_const_v<U> && std::is_volatile_v<U>) {
-				return reinterpret_cast<std::add_cv_t<T>*>(addr);
-			} else if constexpr (std::is_const_v<U>) {
-				return reinterpret_cast<std::add_const_t<T>*>(addr);
-			} else if constexpr (std::is_volatile_v<U>) {
-				return reinterpret_cast<std::add_volatile_t<T>*>(addr);
-			} else {
-				return reinterpret_cast<T*>(addr);
+		std::string out(len, '\0');
+		if (cvt(out.data(), out.length()) == 0) {
+			return std::nullopt;
+		}
+
+		return out;
+	}
+
+	inline bool report_and_error(std::string_view a_msg, const bool a_fail = true, const std::source_location& a_loc = std::source_location::current())
+	{
+		const auto body = [&]() -> std::wstring {
+			const std::filesystem::path p = a_loc.file_name();
+			auto                        filename = p.lexically_normal().generic_string();
+
+			const std::regex r{ R"((?:^|[\\\/])(?:include|src)[\\\/](.*)$)" };
+			std::smatch      matches;
+			if (std::regex_search(filename, matches, r)) {
+				filename = matches[1].str();
 			}
-		}
 
-		template <class T>
-		bool emplace_vtable(T* a_ptr)
-		{
-			auto address = T::VTABLE[0].address();
-			if (!address) {
-				return false;
+			return utf8_to_utf16(std::format("{}({}): {}"sv, filename, a_loc.line(), a_msg)).value_or(L"<character encoding error>"s);
+		}();
+
+		const auto caption = []() {
+			const auto           maxPath = WinAPI::GetMaxPath();
+			std::vector<wchar_t> buf;
+			buf.reserve(maxPath);
+			buf.resize(maxPath / 2);
+			std::uint32_t result;
+			do {
+				buf.resize(buf.size() * 2);
+				result = WinAPI::GetModuleFileName(WinAPI::GetCurrentModule(), buf.data(), static_cast<std::uint32_t>(buf.size()));
+			} while (result && result == buf.size() && buf.size() <= (std::numeric_limits<std::uint32_t>::max)());
+
+			if (result && result != buf.size()) {
+				const std::filesystem::path p(buf.begin(), buf.begin() + result);
+				return p.filename().native();
 			}
-			reinterpret_cast<std::uintptr_t*>(a_ptr)[0] = address;
-			return true;
+			return L""s;
+		}();
+
+		spdlog::log(spdlog::source_loc{ a_loc.file_name(), static_cast<int>(a_loc.line()), a_loc.function_name() }, spdlog::level::critical, a_msg);
+
+		if (a_fail) {
+			WinAPI::MessageBox(nullptr, body.c_str(), (caption.empty() ? nullptr : caption.c_str()), 0);
+			WinAPI::TerminateProcess(WinAPI::GetCurrentProcess(), EXIT_FAILURE);
 		}
+		return true;
+	}
 
-		template <class T>
-		void memzero(volatile T* a_ptr, const std::size_t a_size = sizeof(T))
-		{
-			const auto     begin = reinterpret_cast<volatile char*>(a_ptr);
-			constexpr char val{};
-			std::fill_n(begin, a_size, val);
-		}
+	[[noreturn]] inline void report_and_fail(const std::string_view a_msg, const std::source_location& a_loc = std::source_location::current())
+	{
+		report_and_error(a_msg, true, a_loc);
+		std::unreachable();
+	}
 
-		template <class... Args>
-		[[nodiscard]] auto pun_bits(Args... a_args)
-			requires(std::same_as<std::remove_cv_t<Args>, bool> && ...)
-		{
-			constexpr auto ARGC = sizeof...(Args);
+	template <class Enum>
+	[[nodiscard]] constexpr auto to_underlying(Enum a_val) noexcept
+		requires(std::is_enum_v<Enum>)
+	{
+		return static_cast<std::underlying_type_t<Enum>>(a_val);
+	}
 
-			std::bitset<ARGC> bits;
-			std::size_t       i = 0;
-			((bits[i++] = a_args), ...);
+	template <class To, class From>
+	[[nodiscard]] To unrestricted_cast(From a_from) noexcept
+	{
+		if constexpr (std::is_same_v<std::remove_cv_t<From>, std::remove_cv_t<To>>) {
+			return To{ a_from };
 
-			if constexpr (ARGC <= std::numeric_limits<unsigned long>::digits) {
-				return bits.to_ulong();
-			} else if constexpr (ARGC <= std::numeric_limits<unsigned long long>::digits) {
-				return bits.to_ullong();
-			} else {
-				static_assert(false && sizeof...(Args));
-			}
-		}
+			// From != To
+		} else if constexpr (std::is_reference_v<From>) {
+			return stl::unrestricted_cast<To>(std::addressof(a_from));
 
-		[[nodiscard]] inline auto utf8_to_utf16(const std::string_view a_in) noexcept -> std::optional<std::wstring>
-		{
-			const auto cvt = [&](wchar_t* a_dst, const std::size_t a_length) {
-				return WinAPI::MultiByteToWideChar(
-					WinAPI::CP_UTF8, 0, a_in.data(), static_cast<int>(a_in.length()), a_dst, static_cast<int>(a_length));
+			// From: NOT reference
+		} else if constexpr (std::is_reference_v<To>) {
+			return *stl::unrestricted_cast<std::add_pointer_t<std::remove_reference_t<To>>>(a_from);
+
+			// To: NOT reference
+		} else if constexpr (std::is_pointer_v<From> && std::is_pointer_v<To>) {
+			return static_cast<To>(const_cast<void*>(static_cast<const volatile void*>(a_from)));
+		} else if constexpr ((std::is_pointer_v<From> && std::is_integral_v<To>) || (std::is_integral_v<From> && std::is_pointer_v<To>)) {
+			return reinterpret_cast<To>(a_from);
+		} else {
+			union
+			{
+				std::remove_cv_t<std::remove_reference_t<From>> from;
+				std::remove_cv_t<std::remove_reference_t<To>>   to;
 			};
 
-			const auto len = cvt(nullptr, 0);
-			if (len == 0) {
-				return std::nullopt;
-			}
-
-			std::wstring out(len, '\0');
-			if (cvt(out.data(), out.length()) == 0) {
-				return std::nullopt;
-			}
-
-			return out;
-		}
-
-		[[nodiscard]] inline auto utf16_to_utf8(const std::wstring_view a_in) noexcept -> std::optional<std::string>
-		{
-			const auto cvt = [&](char* a_dst, const std::size_t a_length) {
-				return WinAPI::WideCharToMultiByte(
-					WinAPI::CP_UTF8, 0, a_in.data(), static_cast<int>(a_in.length()), a_dst, static_cast<int>(a_length), nullptr, nullptr);
-			};
-
-			const auto len = cvt(nullptr, 0);
-			if (len == 0) {
-				return std::nullopt;
-			}
-
-			std::string out(len, '\0');
-			if (cvt(out.data(), out.length()) == 0) {
-				return std::nullopt;
-			}
-
-			return out;
-		}
-
-		inline bool report_and_error(std::string_view a_msg, const bool a_fail = true, const std::source_location& a_loc = std::source_location::current())
-		{
-			const auto body = [&]() -> std::wstring {
-				const std::filesystem::path p = a_loc.file_name();
-				auto                        filename = p.lexically_normal().generic_string();
-
-				const std::regex r{ R"((?:^|[\\\/])(?:include|src)[\\\/](.*)$)" };
-				std::smatch      matches;
-				if (std::regex_search(filename, matches, r)) {
-					filename = matches[1].str();
-				}
-
-				return utf8_to_utf16(std::format("{}({}): {}"sv, filename, a_loc.line(), a_msg)).value_or(L"<character encoding error>"s);
-			}();
-
-			const auto caption = []() {
-				const auto           maxPath = WinAPI::GetMaxPath();
-				std::vector<wchar_t> buf;
-				buf.reserve(maxPath);
-				buf.resize(maxPath / 2);
-				std::uint32_t result = 0;
-				do {
-					buf.resize(buf.size() * 2);
-					result = WinAPI::GetModuleFileName(WinAPI::GetCurrentModule(), buf.data(), static_cast<std::uint32_t>(buf.size()));
-				} while (result && result == buf.size() && buf.size() <= (std::numeric_limits<std::uint32_t>::max)());
-
-				if (result && result != buf.size()) {
-					std::filesystem::path p(buf.begin(), buf.begin() + result);
-					return p.filename().native();
-				}
-				return L""s;
-			}();
-
-			spdlog::log(spdlog::source_loc{ a_loc.file_name(), static_cast<int>(a_loc.line()), a_loc.function_name() }, spdlog::level::critical, a_msg);
-
-			if (a_fail) {
-				WinAPI::MessageBox(nullptr, body.c_str(), (caption.empty() ? nullptr : caption.c_str()), 0);
-				WinAPI::TerminateProcess(WinAPI::GetCurrentProcess(), EXIT_FAILURE);
-			}
-			return true;
-		}
-
-		[[noreturn]] inline void report_and_fail(const std::string_view a_msg, const std::source_location& a_loc = std::source_location::current())
-		{
-			report_and_error(a_msg, true, a_loc);
-			std::unreachable();
-		}
-
-		template <class Enum>
-		[[nodiscard]] constexpr auto to_underlying(Enum a_val) noexcept
-			requires(std::is_enum_v<Enum>)
-		{
-			return static_cast<std::underlying_type_t<Enum>>(a_val);
-		}
-
-		template <class To, class From>
-		[[nodiscard]] To unrestricted_cast(From a_from) noexcept
-		{
-			if constexpr (std::is_same_v<std::remove_cv_t<From>, std::remove_cv_t<To>>) {
-				return To{ a_from };
-
-				// From != To
-			} else if constexpr (std::is_reference_v<From>) {
-				return stl::unrestricted_cast<To>(std::addressof(a_from));
-
-				// From: NOT reference
-			} else if constexpr (std::is_reference_v<To>) {
-				return *stl::unrestricted_cast<std::add_pointer_t<std::remove_reference_t<To>>>(a_from);
-
-				// To: NOT reference
-			} else if constexpr (std::is_pointer_v<From> && std::is_pointer_v<To>) {
-				return static_cast<To>(const_cast<void*>(static_cast<const volatile void*>(a_from)));
-			} else if constexpr ((std::is_pointer_v<From> && std::is_integral_v<To>) || (std::is_integral_v<From> && std::is_pointer_v<To>)) {
-				return reinterpret_cast<To>(a_from);
-			} else {
-				union
-				{
-					std::remove_cv_t<std::remove_reference_t<From>> from;
-					std::remove_cv_t<std::remove_reference_t<To>>   to;
-				};
-
-				from = std::forward<From>(a_from);
-				return to;
-			}
+			from = std::forward<From>(a_from);
+			return to;
 		}
 	}
 }

--- a/CommonLibSF/include/SFSE/InputMap.h
+++ b/CommonLibSF/include/SFSE/InputMap.h
@@ -1,53 +1,50 @@
 #pragma once
 
-namespace SFSE
+namespace SFSE::InputMap
 {
-	namespace InputMap
+	enum
 	{
-		enum
-		{
-			// first 256 for keyboard, then 8 mouse buttons, then mouse wheel up, wheel down, then 16 gamepad buttons
-			kMacro_KeyboardOffset = 0,  // not actually used, just for self-documentation
-			kMacro_NumKeyboardKeys = 256,
+		// first 256 for keyboard, then 8 mouse buttons, then mouse wheel up, wheel down, then 16 gamepad buttons
+		kMacro_KeyboardOffset = 0,  // not actually used, just for self-documentation
+		kMacro_NumKeyboardKeys = 256,
 
-			kMacro_MouseButtonOffset = kMacro_NumKeyboardKeys,  // 256
-			kMacro_NumMouseButtons = 8,
+		kMacro_MouseButtonOffset = kMacro_NumKeyboardKeys,  // 256
+		kMacro_NumMouseButtons = 8,
 
-			kMacro_MouseWheelOffset = kMacro_MouseButtonOffset + kMacro_NumMouseButtons,  // 264
-			kMacro_MouseWheelDirections = 2,
+		kMacro_MouseWheelOffset = kMacro_MouseButtonOffset + kMacro_NumMouseButtons,  // 264
+		kMacro_MouseWheelDirections = 2,
 
-			kMacro_GamepadOffset = kMacro_MouseWheelOffset + kMacro_MouseWheelDirections,  // 266
-			kMacro_NumGamepadButtons = 16,
+		kMacro_GamepadOffset = kMacro_MouseWheelOffset + kMacro_MouseWheelDirections,  // 266
+		kMacro_NumGamepadButtons = 16,
 
-			kMaxMacros = kMacro_GamepadOffset + kMacro_NumGamepadButtons  // 282
-		};
+		kMaxMacros = kMacro_GamepadOffset + kMacro_NumGamepadButtons  // 282
+	};
 
-		enum
-		{
-			kGamepadButtonOffset_DPAD_UP = kMacro_GamepadOffset,  // 266
-			kGamepadButtonOffset_DPAD_DOWN,
-			kGamepadButtonOffset_DPAD_LEFT,
-			kGamepadButtonOffset_DPAD_RIGHT,
-			kGamepadButtonOffset_START,
-			kGamepadButtonOffset_BACK,
-			kGamepadButtonOffset_LEFT_THUMB,
-			kGamepadButtonOffset_RIGHT_THUMB,
-			kGamepadButtonOffset_LEFT_SHOULDER,
-			kGamepadButtonOffset_RIGHT_SHOULDER,
-			kGamepadButtonOffset_A,
-			kGamepadButtonOffset_B,
-			kGamepadButtonOffset_X,
-			kGamepadButtonOffset_Y,
-			kGamepadButtonOffset_LT,
-			kGamepadButtonOffset_RT  // 281
-		};
+	enum
+	{
+		kGamepadButtonOffset_DPAD_UP = kMacro_GamepadOffset,  // 266
+		kGamepadButtonOffset_DPAD_DOWN,
+		kGamepadButtonOffset_DPAD_LEFT,
+		kGamepadButtonOffset_DPAD_RIGHT,
+		kGamepadButtonOffset_START,
+		kGamepadButtonOffset_BACK,
+		kGamepadButtonOffset_LEFT_THUMB,
+		kGamepadButtonOffset_RIGHT_THUMB,
+		kGamepadButtonOffset_LEFT_SHOULDER,
+		kGamepadButtonOffset_RIGHT_SHOULDER,
+		kGamepadButtonOffset_A,
+		kGamepadButtonOffset_B,
+		kGamepadButtonOffset_X,
+		kGamepadButtonOffset_Y,
+		kGamepadButtonOffset_LT,
+		kGamepadButtonOffset_RT  // 281
+	};
 
-		constexpr std::uint32_t GamepadMaskToKeycode(std::uint32_t keyMask);
-		constexpr std::uint32_t GamepadKeycodeToMask(std::uint32_t keyCode);
+	constexpr std::uint32_t GamepadMaskToKeycode(std::uint32_t a_keyMask);
+	constexpr std::uint32_t GamepadKeycodeToMask(std::uint32_t a_keyCode);
 
-		constexpr std::string GetKeyName(std::uint32_t keyCode);
-		std::string           GetKeyboardKeyName(std::uint32_t keyCode);
-		constexpr std::string GetMouseButtonName(std::uint32_t keyCode);
-		constexpr std::string GetGamepadButtonName(std::uint32_t a_keyCode);
-	}
+	constexpr std::string GetKeyName(std::uint32_t a_keyCode);
+	std::string           GetKeyboardKeyName(std::uint32_t a_keyCode);
+	constexpr std::string GetMouseButtonName(std::uint32_t a_keyCode);
+	constexpr std::string GetGamepadButtonName(std::uint32_t a_keyCode);
 }

--- a/CommonLibSF/include/SFSE/Trampoline.h
+++ b/CommonLibSF/include/SFSE/Trampoline.h
@@ -40,7 +40,7 @@ namespace SFSE
 		Trampoline() = default;
 		constexpr Trampoline(const Trampoline&) = delete;
 
-		Trampoline(Trampoline&& a_rhs) { move_from(std::move(a_rhs)); }
+		Trampoline(Trampoline&& a_rhs) noexcept { move_from(std::move(a_rhs)); }
 
 		explicit Trampoline(const std::string_view a_name) :
 			_name(a_name) {}
@@ -49,7 +49,7 @@ namespace SFSE
 
 		constexpr Trampoline& operator=(const Trampoline&) = delete;
 
-		constexpr Trampoline& operator=(Trampoline&& a_rhs)
+		constexpr Trampoline& operator=(Trampoline&& a_rhs) noexcept
 		{
 			if (this != std::addressof(a_rhs)) {
 				move_from(std::move(a_rhs));
@@ -174,7 +174,7 @@ namespace SFSE
 		}
 
 	private:
-		[[nodiscard]] void* do_create(std::size_t a_size, std::uintptr_t a_address);
+		[[nodiscard]] static void* do_create(std::size_t a_size, std::uintptr_t a_address);
 
 		[[nodiscard]] constexpr void* do_allocate(const std::size_t a_size)
 		{
@@ -221,7 +221,7 @@ namespace SFSE
 			static_assert(sizeof(TrampolineAssembly) == 0xE);
 #pragma pack(pop)
 
-			TrampolineAssembly* mem = nullptr;
+			TrampolineAssembly* mem;
 			if (const auto it = _5branches.find(a_dst); it != _5branches.end()) {
 				mem = reinterpret_cast<TrampolineAssembly*>(it->second);
 			} else {
@@ -323,7 +323,7 @@ namespace SFSE
 
 		void log_stats() const;
 
-		[[nodiscard]] constexpr bool in_range(const std::ptrdiff_t a_disp) const
+		[[nodiscard]] static constexpr bool in_range(const std::ptrdiff_t a_disp)
 		{
 			constexpr auto min = (std::numeric_limits<std::int32_t>::min)();
 			constexpr auto max = (std::numeric_limits<std::int32_t>::max)();

--- a/CommonLibSF/include/SFSE/Utilities.h
+++ b/CommonLibSF/include/SFSE/Utilities.h
@@ -3,35 +3,32 @@
 #include "REL/Relocation.h"
 #include "SFSE/API.h"
 
-namespace SFSE
+namespace SFSE::stl
 {
-	namespace stl
+	template <class T, std::size_t Size = 5>
+	constexpr void write_thunk_call(const std::uintptr_t a_address) noexcept
 	{
-		template <class T, std::size_t Size = 5>
-		constexpr void write_thunk_call(const std::uintptr_t a_address) noexcept
-		{
-			SFSE::AllocTrampoline(14);
-			auto& trampoline = SFSE::GetTrampoline();
-			T::func = trampoline.write_call<Size>(a_address, T::thunk);
-		}
+		SFSE::AllocTrampoline(14);
+		auto& trampoline = SFSE::GetTrampoline();
+		T::func = trampoline.write_call<Size>(a_address, T::thunk);
+	}
 
-		template <class T, std::size_t Size = 5>
-		constexpr void write_thunk_call() noexcept
-		{
-			write_thunk_call<T, Size>(T::address);
-		}
+	template <class T, std::size_t Size = 5>
+	constexpr void write_thunk_call() noexcept
+	{
+		write_thunk_call<T, Size>(T::address);
+	}
 
-		template <class T>
-		constexpr void write_vfunc(const REL::ID a_id) noexcept
-		{
-			REL::Relocation<std::uintptr_t> vtbl{ a_id };
-			T::func = vtbl.write_vfunc(T::idx, T::thunk);
-		}
+	template <class T>
+	constexpr void write_vfunc(const REL::ID a_id) noexcept
+	{
+		REL::Relocation<std::uintptr_t> vtbl{ a_id };
+		T::func = vtbl.write_vfunc(T::idx, T::thunk);
+	}
 
-		template <class To, class From>
-		constexpr void write_vfunc(const std::size_t a_vtableIdx = 0) noexcept
-		{
-			write_vfunc<From>(To::VTABLE[a_vtableIdx]);
-		}
+	template <class To, class From>
+	constexpr void write_vfunc(const std::size_t a_vtableIdx = 0) noexcept
+	{
+		write_vfunc<From>(To::VTABLE[a_vtableIdx]);
 	}
 }

--- a/CommonLibSF/src/REL/ID.cpp
+++ b/CommonLibSF/src/REL/ID.cpp
@@ -6,7 +6,7 @@ namespace REL
 	{
 		constexpr auto LookUpDir = "Data\\SFSE\\Plugins"sv;
 
-		[[nodiscard]] constexpr std::uint64_t Offset2ID::operator()(std::size_t a_offset) const
+		[[nodiscard]] std::uint64_t Offset2ID::operator()(std::size_t a_offset) const
 		{
 			const mapping_t elem{ 0, a_offset };
 			const auto      it = std::ranges::lower_bound(

--- a/CommonLibSF/src/REL/Module.cpp
+++ b/CommonLibSF/src/REL/Module.cpp
@@ -16,8 +16,8 @@ namespace REL
 		for (std::size_t i = 0; i < size; ++i) {
 			const auto& section = sections[i];
 			const auto  it = std::ranges::find_if(SEGMENTS.begin(), SEGMENTS.end(), [&](auto&& a_elem) {
-                constexpr auto size = std::extent_v<decltype(section.name)>;
-                const auto     len = (std::min)(a_elem.first.size(), size);
+                constexpr auto size_s = std::extent_v<decltype(section.name)>;
+                const auto     len = (std::min)(a_elem.first.size(), size_s);
                 return std::memcmp(a_elem.first.data(), section.name, len) == 0 && (section.characteristics & a_elem.second) == a_elem.second;
             });
 			if (it != SEGMENTS.end()) {

--- a/CommonLibSF/src/REL/Version.cpp
+++ b/CommonLibSF/src/REL/Version.cpp
@@ -6,25 +6,25 @@ namespace REL
 	{
 		std::array<value_type, 4> powers{ 1, 1, 1, 1 };
 		std::size_t               position{};
-		for (std::size_t i = 0; i < a_version.size(); ++i) {
-			if (a_version[i] == '.') {
-				if (++position == powers.size()) {
-					throw std::invalid_argument("Too many parts in version number.");
-				}
-			} else {
-				powers[position] *= 10;
-			}
+		for (const auto& c : a_version) {
+		    if (c == '.') {
+		        if (++position == powers.size()) {
+		            throw std::invalid_argument("Too many parts in version number.");
+		        }
+		    } else {
+		        powers[position] *= 10;
+		    }
 		}
 		position = 0;
-		for (std::size_t i = 0; i < a_version.size(); ++i) {
-			if (a_version[i] == '.') {
-				++position;
-			} else if (a_version[i] < '0' || a_version[i] > '9') {
+		for (const auto& c : a_version) {
+		    if (c == '.') {
+		        ++position;
+		    } else if (c < '0' || c > '9') {
 				throw std::invalid_argument("Invalid character in version number.");
-			} else {
+		    } else {
 				powers[position] /= 10;
-				_impl[position] += static_cast<value_type>((a_version[i] - '0') * powers[position]);
-			}
+				_impl[position] += static_cast<value_type>((c - '0') * powers[position]);
+		    }
 		}
 	}
 

--- a/CommonLibSF/src/SFSE/API.cpp
+++ b/CommonLibSF/src/SFSE/API.cpp
@@ -1,4 +1,5 @@
 #include "SFSE/API.h"
+
 #include "SFSE/Logger.h"
 
 namespace SFSE

--- a/CommonLibSF/src/SFSE/IAT.cpp
+++ b/CommonLibSF/src/SFSE/IAT.cpp
@@ -4,19 +4,19 @@
 
 namespace SFSE
 {
-	std::uintptr_t GetIATAddr(std::string_view a_dll, std::string_view a_function)
+	std::uintptr_t GetIATAddr(const std::string_view a_dll, const std::string_view a_function)
 	{
-		return reinterpret_cast<std::uintptr_t>(GetIATPtr(std::move(a_dll), std::move(a_function)));
+		return reinterpret_cast<std::uintptr_t>(GetIATPtr(a_dll, a_function));
 	}
 
-	std::uintptr_t GetIATAddr(void* a_module, std::string_view a_dll, std::string_view a_function)
+	std::uintptr_t GetIATAddr(void* a_module, const std::string_view a_dll, const std::string_view a_function)
 	{
-		return reinterpret_cast<std::uintptr_t>(GetIATPtr(a_module, std::move(a_dll), std::move(a_function)));
+		return reinterpret_cast<std::uintptr_t>(GetIATPtr(a_module, a_dll, a_function));
 	}
 
-	constexpr void* GetIATPtr(std::string_view a_dll, std::string_view a_function)
+	constexpr void* GetIATPtr(const std::string_view a_dll, const std::string_view a_function)
 	{
-		return GetIATPtr(REL::Module::get().pointer(), std::move(a_dll), std::move(a_function));
+		return GetIATPtr(REL::Module::get().pointer(), a_dll, a_function);
 	}
 
 	// https://guidedhacking.com/attachments/pe_imptbl_headers-jpg.2241/

--- a/CommonLibSF/src/SFSE/InputMap.cpp
+++ b/CommonLibSF/src/SFSE/InputMap.cpp
@@ -4,7 +4,7 @@
 
 namespace SFSE
 {
-	std::uint32_t InputMap::GamepadMaskToKeycode(const std::uint32_t keyMask)
+	std::uint32_t InputMap::GamepadMaskToKeycode(const std::uint32_t a_keyMask)
 	{
 		using XInputButton = RE::XInput::XInputButton;
 		switch (a_keyMask) {
@@ -45,7 +45,7 @@ namespace SFSE
 		}
 	}
 
-	std::uint32_t InputMap::GamepadKeycodeToMask(const std::uint32_t keyCode)
+	std::uint32_t InputMap::GamepadKeycodeToMask(const std::uint32_t a_keyCode)
 	{
 		using XInputButton = RE::XInput::XInputButton;
 

--- a/CommonLibSF/src/SFSE/InputMap.cpp
+++ b/CommonLibSF/src/SFSE/InputMap.cpp
@@ -4,10 +4,10 @@
 
 namespace SFSE
 {
-	constexpr std::uint32_t InputMap::GamepadMaskToKeycode(const std::uint32_t keyMask)
+	constexpr std::uint32_t InputMap::GamepadMaskToKeycode(const std::uint32_t a_keyMask)
 	{
 		using XInputButton = RE::XInput::XInputButton;
-		switch (keyMask) {
+		switch (a_keyMask) {
 		case XInputButton::XINPUT_GAMEPAD_DPAD_UP:
 			return kGamepadButtonOffset_DPAD_UP;
 		case XInputButton::XINPUT_GAMEPAD_DPAD_DOWN:
@@ -45,11 +45,11 @@ namespace SFSE
 		}
 	}
 
-	constexpr std::uint32_t InputMap::GamepadKeycodeToMask(const std::uint32_t keyCode)
+	constexpr std::uint32_t InputMap::GamepadKeycodeToMask(const std::uint32_t a_keyCode)
 	{
 		using XInputButton = RE::XInput::XInputButton;
 
-		switch (keyCode) {
+		switch (a_keyCode) {
 		case kGamepadButtonOffset_DPAD_UP:
 			return XInputButton::XINPUT_GAMEPAD_DPAD_UP;
 		case kGamepadButtonOffset_DPAD_DOWN:

--- a/CommonLibSF/src/SFSE/Interfaces.cpp
+++ b/CommonLibSF/src/SFSE/Interfaces.cpp
@@ -1,4 +1,5 @@
 #include "SFSE/Interfaces.h"
+
 #include "SFSE/API.h"
 #include "SFSE/Logger.h"
 

--- a/CommonLibSF/src/SFSE/Logger.cpp
+++ b/CommonLibSF/src/SFSE/Logger.cpp
@@ -1,4 +1,5 @@
 #include "SFSE/Logger.h"
+
 #include "SFSE/API.h"
 
 #include <spdlog/sinks/basic_file_sink.h>

--- a/CommonLibSF/src/SFSE/Logger.cpp
+++ b/CommonLibSF/src/SFSE/Logger.cpp
@@ -4,49 +4,46 @@
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/msvc_sink.h>
 
-namespace SFSE
+namespace SFSE::log
 {
-	namespace log
+	std::optional<std::filesystem::path> log_directory()
 	{
-		std::optional<std::filesystem::path> log_directory()
-		{
-			wchar_t*                                                           buffer{};
-			const auto                                                         result = WinAPI::SHGetKnownFolderPath(WinAPI::FOLDERID_DOCUMENTS, WinAPI::KF_FLAG_DEFAULT, nullptr, std::addressof(buffer));
-			const std::unique_ptr<wchar_t[], decltype(&WinAPI::CoTaskMemFree)> knownPath(buffer, WinAPI::CoTaskMemFree);
-			if (!knownPath || result != 0) {
-				error("failed to get known folder path"sv);
-				return std::nullopt;
-			}
-
-			std::filesystem::path path = knownPath.get();
-			path /= "My Games\\Starfield\\SFSE\\Logs";
-			return path;
+		wchar_t*                                                           buffer{};
+		const auto                                                         result = WinAPI::SHGetKnownFolderPath(WinAPI::FOLDERID_DOCUMENTS, WinAPI::KF_FLAG_DEFAULT, nullptr, std::addressof(buffer));
+		const std::unique_ptr<wchar_t[], decltype(&WinAPI::CoTaskMemFree)> knownPath(buffer, WinAPI::CoTaskMemFree);
+		if (!knownPath || result != 0) {
+			error("failed to get known folder path"sv);
+			return std::nullopt;
 		}
 
-		void init()
-		{
-			auto path = log_directory();
-			if (!path)
-				return;
+		std::filesystem::path path = knownPath.get();
+		path /= "My Games\\Starfield\\SFSE\\Logs";
+		return path;
+	}
 
-			const auto data = PluginVersionData::GetSingleton();
-			*path /= std::format("{}.log", data->GetPluginName());
+	void init()
+	{
+		auto path = log_directory();
+		if (!path)
+			return;
 
-			std::vector<spdlog::sink_ptr> sinks{
-				std::make_shared<spdlog::sinks::basic_file_sink_mt>(path->string(), true),
-				std::make_shared<spdlog::sinks::msvc_sink_mt>()
-			};
+		const auto data = PluginVersionData::GetSingleton();
+		*path /= std::format("{}.log", data->GetPluginName());
 
-			auto logger = std::make_shared<spdlog::logger>("Global", sinks.begin(), sinks.end());
+		std::vector<spdlog::sink_ptr> sinks{
+			std::make_shared<spdlog::sinks::basic_file_sink_mt>(path->string(), true),
+			std::make_shared<spdlog::sinks::msvc_sink_mt>()
+		};
+
+		auto logger = std::make_shared<spdlog::logger>("Global", sinks.begin(), sinks.end());
 #ifndef NDEBUG
-			logger->set_level(spdlog::level::debug);
-			logger->flush_on(spdlog::level::debug);
+		logger->set_level(spdlog::level::debug);
+		logger->flush_on(spdlog::level::debug);
 #else
-			logger->set_level(spdlog::level::info);
-			logger->flush_on(spdlog::level::info);
+		logger->set_level(spdlog::level::info);
+		logger->flush_on(spdlog::level::info);
 #endif
-			spdlog::set_default_logger(std::move(logger));
-			spdlog::set_pattern("[%T.%e] [%=5t] [%L] %v");
-		}
+		spdlog::set_default_logger(std::move(logger));
+		spdlog::set_pattern("[%T.%e] [%=5t] [%L] %v");
 	}
 }


### PR DESCRIPTION
Should be the last of these stupid refactors for a while

- Remove unnecessary `std::move` calls from IAT.h/cpp
- Make a few functions `static`
- Collapse namespaces in PCH.h, InputMap.h, Utilities.h, and Logger.cpp to reduce nesting
- Add `noexcept` to `Trampoline` move ctor and assignment operator
- Fix a variable name hiding previous definition in Module.cpp
- Switch to range-based for loops in Version.cpp
- Fix `a_paramName` convention in InputMap.cpp
