### PR TITLE
feat: formcomponent definitions

### DIFF
--- a/CommonLibSF/include/RE/B/BGSForcedLocRefType.h
+++ b/CommonLibSF/include/RE/B/BGSForcedLocRefType.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "RE/B/BSTArray.h"
 #include "RE/B/BaseFormComponent.h"
 
 namespace RE
@@ -16,8 +17,7 @@ namespace RE
 		void                 InitializeDataComponent() override;     // 02 - { return; }
 
 		// members
-		std::uint64_t unk08;  // 08
-		std::uint64_t unk10;  // 10
+		BSTArray<void*> unk08;  // 08
 	};
 	static_assert(sizeof(BGSForcedLocRefType) == 0x18);
 }

--- a/CommonLibSF/include/RE/B/BGSMod.h
+++ b/CommonLibSF/include/RE/B/BGSMod.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "RE/B/BSTArray.h"
 #include "RE/B/BaseFormComponent.h"
 
 namespace RE
@@ -25,9 +26,8 @@ namespace RE
 				virtual void Unk_0D();  // 0D
 
 				// members
-				void*         unk08;  // 08
-				void*         unk10;  // 10
-				BSFixedString unk18;  // 18
+				BSTArray<void*> unk08;  // 08
+				BSFixedString   unk18;  // 18
 			};
 			static_assert(sizeof(Items) == 0x20);
 		}

--- a/CommonLibSF/include/RE/B/BGSPerkRankArray.h
+++ b/CommonLibSF/include/RE/B/BGSPerkRankArray.h
@@ -1,19 +1,12 @@
 #pragma once
 
+#include "RE/B/BSTArray.h"
 #include "RE/B/BaseFormComponent.h"
 
 namespace RE
 {
-	class BGSPerk;
-
-	struct PerkRankData
-	{
-		// members
-		BGSPerk*    perk;         // 00
-		std::int8_t currentRank;  // 08
-	};
-	static_assert(sizeof(PerkRankData) == 0x10);
-
+	struct PerkRankData;
+	
 	class BGSPerkRankArray : public BaseFormComponent
 	{
 	public:
@@ -26,8 +19,7 @@ namespace RE
 		void                 InitializeDataComponent() override;     // 02 - { return; }
 
 		// members
-		PerkRankData* perks;      // 08
-		std::uint32_t perkCount;  // 10
+		BSTArray<PerkRankData> perks;  // 08
 	};
 	static_assert(sizeof(BGSPerkRankArray) == 0x18);
 }

--- a/CommonLibSF/include/RE/P/PerkRankData.h
+++ b/CommonLibSF/include/RE/P/PerkRankData.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace RE
+{
+	class BGSPerk;
+
+	struct PerkRankData
+	{
+		// members
+		BGSPerk*    perk;         // 00
+		std::int8_t currentRank;  // 08
+	};
+	static_assert(sizeof(PerkRankData) == 0x10);
+}

--- a/CommonLibSF/include/RE/T/TESContainer.h
+++ b/CommonLibSF/include/RE/T/TESContainer.h
@@ -1,10 +1,22 @@
 #pragma once
 
+#include "RE/B/BSTArray.h"
 #include "RE/B/BaseFormComponent.h"
 
 namespace RE
 {
-	class ContainerObject;
+	class TESBoundObject;
+	struct ContainerItemExtra;
+
+	struct ContainerObject
+	{
+	public:
+		// members
+		std::int32_t        count;      // 00
+		TESBoundObject*     obj;        // 08
+		ContainerItemExtra* itemExtra;  // 10 - COED
+	};
+	static_assert(sizeof(ContainerObject) == 0x18);
 
 	class TESContainer : public BaseFormComponent
 	{
@@ -18,8 +30,7 @@ namespace RE
 		void                 InitializeDataComponent() override;     // 02 - { return; }
 
 		// members
-		ContainerObject** containerObjects;     // 08
-		std::uint32_t     numContainerObjects;  // 10
+		BSTArray<ContainerObject> containerObjects;  // 08
 	};
 	static_assert(sizeof(TESContainer) == 0x18);
 }

--- a/CommonLibSF/include/RE/T/TESSpellList.h
+++ b/CommonLibSF/include/RE/T/TESSpellList.h
@@ -1,9 +1,12 @@
 #pragma once
 
+#include "RE/B/BSTArray.h"
 #include "RE/B/BaseFormComponent.h"
 
 namespace RE
 {
+	class SpellItem;
+
 	class TESSpellList : public BaseFormComponent
 	{
 	public:
@@ -16,9 +19,7 @@ namespace RE
 		void                 InitializeDataComponent() override;     // 02 - { return; }
 
 		// members
-		std::uint32_t unk08;  // 08
-		std::uint32_t unk0C;  // 0C
-		std::uint64_t unk10;  // 10
+		BSTArray<SpellItem*> spells;  // 08
 	};
 	static_assert(sizeof(TESSpellList) == 0x18);
 }


### PR DESCRIPTION
- `PerkRankData` has been split into its own header since it's also used in `Actor` class