### PR TITLE
feat: improve `Settings` & related

### DIFF
--- a/CommonLibSF/include/RE/I/INISettingCollection.h
+++ b/CommonLibSF/include/RE/I/INISettingCollection.h
@@ -29,5 +29,25 @@ namespace RE
 
 			return nullptr;
 		}
+
+		template <class T>
+		T GetSetting(const std::string_view a_name, T a_fallback)
+		{
+			if (auto setting = GetSetting(a_name)) {
+				return setting->GetValue(a_fallback);
+			}
+
+			return a_fallback;
+		}
+
+		template <class T>
+		bool SetSetting(const std::string_view a_name, T a_value)
+		{
+			if (auto setting = GetSetting(a_name)) {
+				return setting->SetValue(a_value);
+			}
+
+			return false;
+		}
 	};
 }

--- a/CommonLibSF/include/RE/I/INISettingCollection.h
+++ b/CommonLibSF/include/RE/I/INISettingCollection.h
@@ -31,10 +31,10 @@ namespace RE
 		}
 
 		template <class T>
-		T GetSetting(const std::string_view a_name, T a_fallback)
+		T GetSetting(const std::string_view a_name, T a_fallback, const bool a_default = false)
 		{
 			if (auto setting = GetSetting(a_name)) {
-				return setting->GetValue(a_fallback);
+				return setting->GetValue(a_fallback, a_default);
 			}
 
 			return a_fallback;

--- a/CommonLibSF/include/RE/I/INISettingCollection.h
+++ b/CommonLibSF/include/RE/I/INISettingCollection.h
@@ -33,7 +33,7 @@ namespace RE
 		template <class T>
 		T GetSetting(const std::string_view a_name, T a_fallback, const bool a_default = false)
 		{
-			if (auto setting = GetSetting(a_name)) {
+			if (const auto setting = GetSetting(a_name)) {
 				return setting->GetValue(a_fallback, a_default);
 			}
 
@@ -43,7 +43,7 @@ namespace RE
 		template <class T>
 		bool SetSetting(const std::string_view a_name, T a_value)
 		{
-			if (auto setting = GetSetting(a_name)) {
+			if (const auto setting = GetSetting(a_name)) {
 				return setting->SetValue(a_value);
 			}
 

--- a/CommonLibSF/include/RE/R/RegSettingCollection.h
+++ b/CommonLibSF/include/RE/R/RegSettingCollection.h
@@ -29,5 +29,25 @@ namespace RE
 
 			return nullptr;
 		}
+
+		template <class T>
+		T GetSetting(const std::string_view a_name, T a_fallback)
+		{
+			if (auto setting = GetSetting(a_name)) {
+				return setting->GetValue(a_fallback);
+			}
+
+			return a_fallback;
+		}
+
+		template <class T>
+		bool SetSetting(const std::string_view a_name, T a_value)
+		{
+			if (auto setting = GetSetting(a_name)) {
+				return setting->SetValue(a_value);
+			}
+
+			return false;
+		}
 	};
 }

--- a/CommonLibSF/include/RE/R/RegSettingCollection.h
+++ b/CommonLibSF/include/RE/R/RegSettingCollection.h
@@ -31,10 +31,10 @@ namespace RE
 		}
 
 		template <class T>
-		T GetSetting(const std::string_view a_name, T a_fallback)
+		T GetSetting(const std::string_view a_name, T a_fallback, const bool a_default = false)
 		{
 			if (auto setting = GetSetting(a_name)) {
-				return setting->GetValue(a_fallback);
+				return setting->GetValue(a_fallback, a_default);
 			}
 
 			return a_fallback;

--- a/CommonLibSF/include/RE/R/RegSettingCollection.h
+++ b/CommonLibSF/include/RE/R/RegSettingCollection.h
@@ -33,7 +33,7 @@ namespace RE
 		template <class T>
 		T GetSetting(const std::string_view a_name, T a_fallback, const bool a_default = false)
 		{
-			if (auto setting = GetSetting(a_name)) {
+			if (const auto setting = GetSetting(a_name)) {
 				return setting->GetValue(a_fallback, a_default);
 			}
 
@@ -43,7 +43,7 @@ namespace RE
 		template <class T>
 		bool SetSetting(const std::string_view a_name, T a_value)
 		{
-			if (auto setting = GetSetting(a_name)) {
+			if (const auto setting = GetSetting(a_name)) {
 				return setting->SetValue(a_value);
 			}
 

--- a/CommonLibSF/include/RE/S/Setting.h
+++ b/CommonLibSF/include/RE/S/Setting.h
@@ -6,8 +6,7 @@ namespace RE
 	{
 	public:
 		SF_RTTI_VTABLE(Setting);
-		// FIXME: MemoryManager unimplemented
-		// SF_HEAP_REDEFINE_NEW(Setting);
+		SF_HEAP_REDEFINE_NEW(Setting);
 
 		enum class Type
 		{
@@ -105,28 +104,61 @@ namespace RE
 			return Type::kNone;
 		}
 
+		template <class T>
+		bool Is() const noexcept
+		{
+			if constexpr (std::is_same_v<T, bool>)
+				return GetType() == Type::kBool;
+			else if constexpr (std::is_same_v<T, std::int8_t>)
+				return GetType() == Type::kChar;
+			else if constexpr (std::is_same_v<T, std::uint8_t>)
+				return GetType() == Type::kUChar;
+			else if constexpr (std::is_same_v<T, std::int32_t>)
+				return GetType() == Type::kInt;
+			else if constexpr (std::is_same_v<T, std::uint32_t>)
+				return GetType() == Type::kUInt;
+			else if constexpr (std::is_same_v<T, float>)
+				return GetType() == Type::kFloat;
+			else if constexpr (std::is_convertible_v<T, std::string_view>)
+				return GetType() == Type::kString;
+			else
+				return false;
+		}
+
 		[[nodiscard]] auto GetBool(const bool a_default = false) const noexcept
 		{
 			assert(GetType() == Type::kBool);
-			return a_default ? _value.b : _defaultValue.b;
+			return a_default ? _defaultValue.b : _value.b;
 		}
 
 		[[nodiscard]] auto GetChar(const bool a_default = false) const noexcept
 		{
 			assert(GetType() == Type::kChar);
-			return a_default ? _value.c : _defaultValue.c;
+			return a_default ? _defaultValue.c : _value.c;
+		}
+
+		[[nodiscard]] auto GetUChar(const bool a_default = false) const noexcept
+		{
+			assert(GetType() == Type::kUChar);
+			return a_default ? _defaultValue.h : _value.h;
 		}
 
 		[[nodiscard]] auto GetFloat(const bool a_default = false) const noexcept
 		{
 			assert(GetType() == Type::kFloat);
-			return a_default ? _value.f : _defaultValue.f;
+			return a_default ? _defaultValue.f : _value.f;
 		}
 
 		[[nodiscard]] auto GetInt(const bool a_default = false) const noexcept
 		{
 			assert(GetType() == Type::kInt);
-			return a_default ? _value.i : _defaultValue.i;
+			return a_default ? _defaultValue.i : _value.i;
+		}
+
+		[[nodiscard]] auto GetUInt(const bool a_default = false) const noexcept
+		{
+			assert(GetType() == Type::kUInt);
+			return a_default ? _defaultValue.u : _value.u;
 		}
 
 		[[nodiscard]] auto GetString(const bool a_default = false) const noexcept
@@ -140,68 +172,149 @@ namespace RE
 			return ""sv;
 		}
 
-		[[nodiscard]] auto GetUChar(const bool a_default = false) const noexcept
+		template <class T>
+		[[nodiscard]] T GetValue(T a_fallback, const bool a_default = false) const noexcept
 		{
-			assert(GetType() == Type::kUChar);
-			return a_default ? _value.h : _defaultValue.h;
+			if (Is<T>()) {
+				if constexpr (std::is_same_v<T, bool>)
+					return GetBool(a_default);
+				else if constexpr (std::is_same_v<T, std::int8_t>)
+					return GetChar(a_default);
+				else if constexpr (std::is_same_v<T, std::uint8_t>)
+					return GetUChar(a_default);
+				else if constexpr (std::is_same_v<T, std::int32_t>)
+					return GetInt(a_default);
+				else if constexpr (std::is_same_v<T, std::uint32_t>)
+					return GetUInt(a_default);
+				else if constexpr (std::is_same_v<T, float>)
+					return GetFloat(a_default);
+				else if constexpr (std::is_convertible_v<T, std::string_view>)
+					return GetString(a_default);
+			}
+
+			return a_fallback;
 		}
 
-		[[nodiscard]] auto GetUInt(const bool a_default = false) const noexcept
+		void SetBool(const bool a_value) noexcept
+		{
+			assert(GetType() == Type::kBool);
+			_value.b = a_value;
+		}
+
+		void SetChar(const std::int8_t a_value) noexcept
+		{
+			assert(GetType() == Type::kChar);
+			_value.c = a_value;
+		}
+
+		void SetUChar(const std::uint8_t a_value) noexcept
+		{
+			assert(GetType() == Type::kUChar);
+			_value.h = a_value;
+		}
+
+		void SetInt(const std::int32_t a_value) noexcept
+		{
+			assert(GetType() == Type::kInt);
+			_value.i = a_value;
+		}
+
+		void SetUInt(const std::uint32_t a_value) noexcept
 		{
 			assert(GetType() == Type::kUInt);
-			return a_default ? _value.u : _defaultValue.u;
+			_value.u = a_value;
+		}
+
+		void SetFloat(const float a_value) noexcept
+		{
+			assert(GetType() == Type::kFloat);
+			_value.f = a_value;
+		}
+
+		void SetString(char* a_value) noexcept
+		{
+			assert(GetType() == Type::kString);
+			_value.s = a_value;
+		}
+
+		void SetString(const char* a_value) noexcept
+		{
+			assert(GetType() == Type::kString);
+			_value.s = _strdup(a_value);
+		}
+
+		template <class T>
+		bool SetValue(T a_value) noexcept
+		{
+			if (Is<T>()) {
+				if constexpr (std::is_same_v<T, bool>)
+					SetBool(a_value);
+				else if constexpr (std::is_same_v<T, std::int8_t>)
+					SetChar(a_value);
+				else if constexpr (std::is_same_v<T, std::uint8_t>)
+					SetUChar(a_value);
+				else if constexpr (std::is_same_v<T, std::int32_t>)
+					SetInt(a_value);
+				else if constexpr (std::is_same_v<T, std::uint32_t>)
+					SetUInt(a_value);
+				else if constexpr (std::is_same_v<T, float>)
+					SetFloat(a_value);
+				else if constexpr (std::is_convertible_v<T, std::string_view>)
+					SetString(a_value);
+					
+				return true;
+			}
+
+			return false;
 		}
 
 		Setting& operator=(const bool a_value)
 		{
-			assert(GetType() == Type::kBool);
-			_value.b = a_value;
+			SetBool(a_value);
 			return *this;
 		}
 
 		Setting& operator=(const std::int8_t a_value)
 		{
-			assert(GetType() == Type::kChar);
-			_value.c = a_value;
+			SetChar(a_value);
 			return *this;
 		}
 
 		Setting& operator=(const std::uint8_t a_value)
 		{
-			assert(GetType() == Type::kUChar);
-			_value.h = a_value;
+			SetUChar(a_value);
 			return *this;
 		}
 
 		Setting& operator=(const std::int32_t a_value)
 		{
-			assert(GetType() == Type::kInt);
-			_value.i = a_value;
+			SetInt(a_value);
 			return *this;
 		}
 
 		Setting& operator=(const std::uint32_t a_value)
 		{
-			assert(GetType() == Type::kUInt);
-			_value.u = a_value;
+			SetUInt(a_value);
 			return *this;
 		}
 
 		Setting& operator=(const float a_value)
 		{
-			assert(GetType() == Type::kFloat);
-			_value.f = a_value;
+			SetFloat(a_value);
 			return *this;
 		}
 
-		// TODO: Verify
-		/*
+		Setting& operator=(char* a_value)
+		{
+			SetString(a_value);
+			return *this;
+		}
+
 		Setting& operator=(const char* a_value)
 		{
-			assert(GetType() == Type::kString);
-			_value.s = _strdup(a_value);
+			SetString(a_value);
 			return *this;
-		}*/
+		}
 
 	private:
 		union Value
@@ -218,7 +331,7 @@ namespace RE
 		};
 		static_assert(sizeof(Value) == 0x8);
 
-		// member
+		// members
 		Value       _value;         // 08
 		Value       _defaultValue;  // 10
 		const char* _key;           // 18


### PR DESCRIPTION
- added helper functions to quickly `Get`/`Set` a setting's value in a collection (if it exists). If `Get` fails, it returns the user provided fallback value. If `Set` fails, it returns false.
- fixed the direct `Setting::GetX` functions returning the wrong value when default is enabled