### PR TITLE
chore: CMakeLists and CMakePresets cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,18 +2,18 @@ cmake_minimum_required(VERSION 3.26)
 
 # singleton target across multiple projects
 if(TARGET CommonLib)
-	return()
+  return()
 endif()
 
 # info
 project(
-	CommonLib
-	LANGUAGES CXX
+  CommonLib
+  LANGUAGES CXX
 )
 
 # out-of-source builds only
 if(${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR})
-	message(FATAL_ERROR "In-source builds are not allowed.")
+  message(FATAL_ERROR "In-source builds are not allowed.")
 endif()
 
 add_subdirectory(CommonLibSF)

--- a/CommonLibSF/CMakeLists.txt
+++ b/CommonLibSF/CMakeLists.txt
@@ -3,170 +3,174 @@ message("Using toolchain file ${CMAKE_TOOLCHAIN_FILE}.")
 
 # singleton target across multiple projects
 if(TARGET CommonLibSF)
-	return()
+  return()
 endif()
 
 # options if not defined
 option(SFSE_SUPPORT_XBYAK "Enables trampoline support for Xbyak." OFF)
+
+# info
+project(
+  CommonLibSF
+  LANGUAGES CXX
+)
 
 # standards & flags
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_DEBUG OFF)
-set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+set(CMAKE_OPTIMIZE_DEPENDENCIES ON)
 
-# info
-project(
-	CommonLibSF
-	LANGUAGES CXX
-	VERSION 1.0.0
-)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 include(GNUInstallDirs)
 
 # out-of-source builds only
 if(${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR})
-	message(FATAL_ERROR "In-source builds are not allowed.")
+  message(FATAL_ERROR "In-source builds are not allowed.")
 endif()
 
 # dependencies
 find_package(spdlog CONFIG REQUIRED)
 
 # source files
-execute_process(COMMAND powershell -ExecutionPolicy Bypass -File "${CMAKE_CURRENT_SOURCE_DIR}/cmake/make-sourcelist.ps1" "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
+execute_process(
+  COMMAND powershell -ExecutionPolicy Bypass -File "${CMAKE_CURRENT_SOURCE_DIR}/cmake/make-sourcelist.ps1" "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}"
+)
+
 include(${CMAKE_CURRENT_BINARY_DIR}/sourcelist.cmake)
+
 source_group(
-	TREE ${CMAKE_CURRENT_SOURCE_DIR}
-	FILES ${SOURCES}
+  TREE ${CMAKE_CURRENT_SOURCE_DIR}
+  FILES ${SOURCES}
 )
 
 add_library(
-	${PROJECT_NAME}
-	STATIC
-	${SOURCES}
-	.clang-format
+  ${PROJECT_NAME}
+  STATIC
+    ${SOURCES}
+    .clang-format
 )
 
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_compile_definitions(
-	${PROJECT_NAME}
-	PUBLIC
-		WINVER=0x0A00	# windows 10, minimum supported version by starfield
-		_WIN32_WINNT=0x0A00
-		"$<$<BOOL:${SFSE_SUPPORT_XBYAK}>:SFSE_SUPPORT_XBYAK=1>"
+  ${PROJECT_NAME}
+  PUBLIC
+    WINVER=0x0A00	# windows 10, minimum supported version by starfield
+    _WIN32_WINNT=0x0A00
+    "$<$<BOOL:${SFSE_SUPPORT_XBYAK}>:SFSE_SUPPORT_XBYAK=1>"
 )
 
 # FIXME: https://gitlab.kitware.com/cmake/cmake/-/issues/24922
 set_property(
-	TARGET
-	${PROJECT_NAME}
-	PROPERTY VS_USER_PROPS
-	"${CMAKE_CURRENT_SOURCE_DIR}/cmake/build_stl_modules.props"
+  TARGET ${PROJECT_NAME}
+  PROPERTY VS_USER_PROPS
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/build_stl_modules.props"
 )
 
-if (MSVC)
-	target_compile_options(
-		${PROJECT_NAME}
-		PUBLIC
-			/bigobj # support large object file format
-			/utf-8  # assume UTF-8 sources even without a BOM
+if(MSVC)
+  target_compile_options(
+    ${PROJECT_NAME}
+    PUBLIC
+      /bigobj # support large object file format
+      /utf-8  # assume UTF-8 sources even without a BOM
 
-			# warnings -> errors
-			/we4715	# 'function' : not all control paths return a value
+    # warnings -> errors
+      /we4715	# 'function' : not all control paths return a value
 
-			# disable warnings
-			/wd4005 # macro redefinition
-			/wd4061 # enumerator 'identifier' in switch of enum 'enumeration' is not explicitly handled by a case label
-			/wd4068 # unknown pragma
-			/wd4200 # nonstandard extension used : zero-sized array in struct/union
-			/wd4201 # nonstandard extension used : nameless struct/union
-			/wd4265 # 'type': class has virtual functions, but its non-trivial destructor is not virtual; instances of this class may not be destructed correctly
-			/wd4266 # 'function' : no override available for virtual member function from base 'type'; function is hidden
-			/wd4267 # 'var' : conversion from 'size_t' to 'type', possible loss of data
-			/wd4371 # 'classname': layout of class may have changed from a previous version of the compiler due to better packing of member 'member'
-			/wd4514 # 'function' : unreferenced inline function has been removed
-			/wd4582 # 'type': constructor is not implicitly called
-			/wd4583 # 'type': destructor is not implicitly called
-			/wd4623 # 'derived class' : default constructor was implicitly defined as deleted because a base class default constructor is inaccessible or deleted
-			/wd4625 # 'derived class' : copy constructor was implicitly defined as deleted because a base class copy constructor is inaccessible or deleted
-			/wd4626 # 'derived class' : assignment operator was implicitly defined as deleted because a base class assignment operator is inaccessible or deleted
-			/wd4710 # 'function' : function not inlined
-			/wd4711 # function 'function' selected for inline expansion
-			/wd4820 # 'bytes' bytes padding added after construct 'member_name'
-			/wd4996
-			/wd5026 # 'type': move constructor was implicitly defined as deleted
-			/wd5027 # 'type': move assignment operator was implicitly defined as deleted
-			/wd5045 # Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
-			/wd5053 # support for 'explicit(<expr>)' in C++17 and earlier is a vendor extension
-			/wd5204 # 'type-name': class has virtual functions, but its trivial destructor is not virtual; instances of objects derived from this class may not be destructed correctly
-			/wd5220 # 'member': a non-static data member with a volatile qualified type no longer implies that compiler generated copy / move constructors and copy / move assignment operators are not trivial
-	)
+    # disable warnings
+      /wd4005 # macro redefinition
+      /wd4061 # enumerator 'identifier' in switch of enum 'enumeration' is not explicitly handled by a case label
+      /wd4068 # unknown pragma
+      /wd4200 # nonstandard extension used : zero-sized array in struct/union
+      /wd4201 # nonstandard extension used : nameless struct/union
+      /wd4265 # 'type': class has virtual functions, but its non-trivial destructor is not virtual; instances of this class may not be destructed correctly
+      /wd4266 # 'function' : no override available for virtual member function from base 'type'; function is hidden
+      /wd4267 # 'var' : conversion from 'size_t' to 'type', possible loss of data
+      /wd4371 # 'classname': layout of class may have changed from a previous version of the compiler due to better packing of member 'member'
+      /wd4514 # 'function' : unreferenced inline function has been removed
+      /wd4582 # 'type': constructor is not implicitly called
+      /wd4583 # 'type': destructor is not implicitly called
+      /wd4623 # 'derived class' : default constructor was implicitly defined as deleted because a base class default constructor is inaccessible or deleted
+      /wd4625 # 'derived class' : copy constructor was implicitly defined as deleted because a base class copy constructor is inaccessible or deleted
+      /wd4626 # 'derived class' : assignment operator was implicitly defined as deleted because a base class assignment operator is inaccessible or deleted
+      /wd4710 # 'function' : function not inlined
+      /wd4711 # function 'function' selected for inline expansion
+      /wd4820 # 'bytes' bytes padding added after construct 'member_name'
+      /wd4996
+      /wd5026 # 'type': move constructor was implicitly defined as deleted
+      /wd5027 # 'type': move assignment operator was implicitly defined as deleted
+      /wd5045 # Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
+      /wd5053 # support for 'explicit(<expr>)' in C++17 and earlier is a vendor extension
+      /wd5204 # 'type-name': class has virtual functions, but its trivial destructor is not virtual; instances of objects derived from this class may not be destructed correctly
+      /wd5220 # 'member': a non-static data member with a volatile qualified type no longer implies that compiler generated copy / move constructors and copy / move assignment operators are not trivial
+  )
 endif()
 
 target_include_directories(
-	${PROJECT_NAME}
-	PUBLIC
-		"$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-		"$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+  ${PROJECT_NAME}
+  PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
 target_link_libraries(
-	${PROJECT_NAME}
-	PUBLIC
-		spdlog::spdlog
-		Version.lib
-		Dbghelp.lib
+  ${PROJECT_NAME}
+  PUBLIC
+    spdlog::spdlog
+    Version.lib
+    Dbghelp.lib
 )
 
-if (SFSE_SUPPORT_XBYAK)
+if(SFSE_SUPPORT_XBYAK)
 find_package(xbyak CONFIG REQUIRED)
 
 target_link_libraries(
-	${PROJECT_NAME}
-	PUBLIC
-		xbyak::xbyak
+  ${PROJECT_NAME}
+  PUBLIC
+    xbyak::xbyak
 )
 endif()
 
 target_precompile_headers(
-	${PROJECT_NAME}
-	PRIVATE
-		include/SFSE/Impl/PCH.h
+  ${PROJECT_NAME}
+  PRIVATE
+    include/SFSE/Impl/PCH.h
 )
 
 install(
-	TARGETS ${PROJECT_NAME}
-	EXPORT ${PROJECT_NAME}-targets
+  TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}-targets
 )
 
 install(
-	EXPORT ${PROJECT_NAME}-targets
-	NAMESPACE ${PROJECT_NAME}::
-	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}-targets
+  NAMESPACE ${PROJECT_NAME}::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )
 
 configure_file(
-	cmake/config.cmake.in
-	${PROJECT_NAME}Config.cmake
-	@ONLY
+  cmake/config.cmake.in
+  ${PROJECT_NAME}Config.cmake
+  @ONLY
 )
 
 install(
-	FILES cmake/CommonLibSF.cmake
-	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+  FILES cmake/CommonLibSF.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )
 
 install(
-	FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )
 
 install(
-	DIRECTORY
-		include/RE
-		include/REL
-		include/SFSE
-	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  DIRECTORY
+    include/RE
+    include/REL
+    include/SFSE
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )

--- a/CommonLibSF/CMakePresets.json
+++ b/CommonLibSF/CMakePresets.json
@@ -10,7 +10,7 @@
       "name": "common",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "$env{PROJECT_PLATFORM_FLAGS} $env{PROJECT_TEXT_FLAGS} $env{PROJECT_COMPILER_FLAGS} $penv{CXXFLAGS}",
+        "CMAKE_CXX_FLAGS": "$env{PROJECT_COMPILER_FLAGS} $penv{CXXFLAGS}",
         "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
       }
     },
@@ -27,8 +27,7 @@
       "name": "buildtype-debug-msvc",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_SHARED_LINKER_FLAGS_DEBUG": "/CGTHREADS:8 /DEBUG:FULL /DEBUGTYPE:FIXUP"
+        "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
@@ -36,16 +35,14 @@
       "hidden": true,
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_CXX_FLAGS_RELEASE": "/fp:fast /GR- /Gw /O2 /Ob3 /Qpar",
-        "CMAKE_SHARED_LINKER_FLAGS_RELEASE": "/CGTHREADS:8 /OPT:ICF=4"
+        "CMAKE_CXX_FLAGS_RELEASE": "/fp:fast /GR- /Gw /O2 /Ob3 /Qpar"
       }
     },
     {
       "name": "buildtype-debug-clang-cl",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_SHARED_LINKER_FLAGS_DEBUG": "/DEBUG:FULL /DEBUGTYPE:FIXUP"
+        "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
@@ -53,14 +50,16 @@
       "hidden": true,
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_CXX_FLAGS_RELEASE": "/fp:fast /GR- /Gw /O2",
-        "CMAKE_SHARED_LINKER_FLAGS_RELEASE": "/OPT:ICF=4"
+        "CMAKE_CXX_FLAGS_RELEASE": "/fp:fast /GR- /Gw /O2"
       }
     },
     {
       "name": "x64",
       "hidden": true,
-      "architecture": "x64"
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      }
     },
     {
       "name": "generator-msvc",
@@ -82,8 +81,7 @@
       "vendor": {
         "microsoft.com/VisualStudioSettings/CMake/1.0": {
           "intelliSenseMode": "windows-msvc-x64",
-          "enableMicrosoftCodeAnalysis": true,
-          "enableClangTidyCodeAnalysis": true
+          "enableMicrosoftCodeAnalysis": true
         }
       }
     },


### PR DESCRIPTION
- Remove `VERSION` field from `project()` call in CMakeLists.txt
- Enable `CMAKE_OPTIMIZE_DEPENDENCIES`
- Remove unused `CMAKE_SHARED_LINKER_FLAGS_<CONFIG>` cache variables from CMakePresets.json
- Formatting