### PR TITLE
refactor: cleanup

### DIFF
--- a/CommonLibSF/include/RE/A/ActorValueOwner.h
+++ b/CommonLibSF/include/RE/A/ActorValueOwner.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "RE/A/ActorValueInfo.h"
 #include "RE/A/ActorValues.h"
 
 namespace RE

--- a/CommonLibSF/include/RE/A/Array.h
+++ b/CommonLibSF/include/RE/A/Array.h
@@ -1,90 +1,82 @@
 #pragma once
 
-#include "RE/B/BSContainer.h"
-#include "RE/B/BSFixedString.h"
 #include "RE/B/BSIntrusiveRefCounted.h"
 #include "RE/B/BSLock.h"
 #include "RE/B/BSTArray.h"
-#include "RE/B/BSTEvent.h"
-#include "RE/B/BSTSmartPointer.h"
-#include "RE/M/MemoryManager.h"
 #include "RE/T/TypeInfo.h"
 #include "RE/V/Variable.h"
 
-namespace RE
+namespace RE::BSScript
 {
-	namespace BSScript
+	class TypeInfo;
+	class Variable;
+
+	class Array :
+		public BSIntrusiveRefCounted  // 00
 	{
-		class TypeInfo;
-		class Variable;
+	private:
+		Array* ctor(const TypeInfo* type_info, std::uint32_t initial_size = 0);
+		void   dtor();
 
-		class Array :
-			public BSIntrusiveRefCounted  // 00
-		{
-		private:
-			Array* ctor(const TypeInfo* type_info, std::uint32_t initial_size = 0);
-			void   dtor();
+	public:
+		using value_type = Variable;
+		using size_type = std::uint32_t;
+		using difference_type = std::int32_t;
+		using reference = value_type&;
+		using const_reference = const value_type&;
+		using pointer = value_type*;
+		using const_pointer = const value_type*;
+		using iterator = value_type*;
+		using const_iterator = const value_type*;
+		using reverse_iterator = std::reverse_iterator<iterator>;
+		using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
-		public:
-			using value_type = Variable;
-			using size_type = std::uint32_t;
-			using difference_type = std::int32_t;
-			using reference = value_type&;
-			using const_reference = const value_type&;
-			using pointer = value_type*;
-			using const_pointer = const value_type*;
-			using iterator = value_type*;
-			using const_iterator = const value_type*;
-			using reverse_iterator = std::reverse_iterator<iterator>;
-			using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+		Array(const TypeInfo* type_info, std::uint32_t initial_size = 0);
+		~Array();
 
-			Array(const TypeInfo* type_info, std::uint32_t initial_size = 0);
-			~Array();
+		[[nodiscard]] reference       operator[](size_type a_pos);
+		[[nodiscard]] const_reference operator[](size_type a_pos) const;
 
-			[[nodiscard]] reference       operator[](size_type a_pos);
-			[[nodiscard]] const_reference operator[](size_type a_pos) const;
+		[[nodiscard]] reference       front();
+		[[nodiscard]] const_reference front() const;
 
-			[[nodiscard]] reference       front();
-			[[nodiscard]] const_reference front() const;
+		[[nodiscard]] reference       back();
+		[[nodiscard]] const_reference back() const;
 
-			[[nodiscard]] reference       back();
-			[[nodiscard]] const_reference back() const;
+		[[nodiscard]] pointer       data() noexcept;
+		[[nodiscard]] const_pointer data() const noexcept;
 
-			[[nodiscard]] pointer       data() noexcept;
-			[[nodiscard]] const_pointer data() const noexcept;
+		[[nodiscard]] iterator       begin() noexcept;
+		[[nodiscard]] const_iterator begin() const noexcept;
+		[[nodiscard]] const_iterator cbegin() const noexcept;
 
-			[[nodiscard]] iterator       begin() noexcept;
-			[[nodiscard]] const_iterator begin() const noexcept;
-			[[nodiscard]] const_iterator cbegin() const noexcept;
+		[[nodiscard]] iterator       end() noexcept;
+		[[nodiscard]] const_iterator end() const noexcept;
+		[[nodiscard]] const_iterator cend() const noexcept;
 
-			[[nodiscard]] iterator       end() noexcept;
-			[[nodiscard]] const_iterator end() const noexcept;
-			[[nodiscard]] const_iterator cend() const noexcept;
+		[[nodiscard]] reverse_iterator       rbegin() noexcept;
+		[[nodiscard]] const_reverse_iterator rbegin() const noexcept;
+		[[nodiscard]] const_reverse_iterator crbegin() const noexcept;
 
-			[[nodiscard]] reverse_iterator       rbegin() noexcept;
-			[[nodiscard]] const_reverse_iterator rbegin() const noexcept;
-			[[nodiscard]] const_reverse_iterator crbegin() const noexcept;
+		[[nodiscard]] reverse_iterator       rend() noexcept;
+		[[nodiscard]] const_reverse_iterator rend() const noexcept;
+		[[nodiscard]] const_reverse_iterator crend() const noexcept;
 
-			[[nodiscard]] reverse_iterator       rend() noexcept;
-			[[nodiscard]] const_reverse_iterator rend() const noexcept;
-			[[nodiscard]] const_reverse_iterator crend() const noexcept;
+		[[nodiscard]] bool empty() const noexcept;
 
-			[[nodiscard]] bool empty() const noexcept;
+		[[nodiscard]] size_type size() const noexcept;
 
-			[[nodiscard]] size_type size() const noexcept;
+		[[nodiscard]] size_type max_size() const noexcept;
 
-			[[nodiscard]] size_type max_size() const noexcept;
+		[[nodiscard]] TypeInfo&       type_info();
+		[[nodiscard]] const TypeInfo& type_info() const;
 
-			[[nodiscard]] TypeInfo&       type_info();
-			[[nodiscard]] const TypeInfo& type_info() const;
+		[[nodiscard]] TypeInfo::RawType type() const;
 
-			[[nodiscard]] TypeInfo::RawType type() const;
-
-			// members
-			TypeInfo           elementType;   // 08
-			BSSpinLock         elementsLock;  // 10
-			BSTArray<Variable> elements;      // 18
-		};
-		static_assert(sizeof(Array) == 0x28);
-	}
+		// members
+		TypeInfo           elementType;   // 08
+		BSSpinLock         elementsLock;  // 10
+		BSTArray<Variable> elements;      // 18
+	};
+	static_assert(sizeof(Array) == 0x28);
 }

--- a/CommonLibSF/include/RE/B/BGSMod.h
+++ b/CommonLibSF/include/RE/B/BGSMod.h
@@ -3,33 +3,27 @@
 #include "RE/B/BSTArray.h"
 #include "RE/B/BaseFormComponent.h"
 
-namespace RE
+namespace RE::BGSMod::Template
 {
-	namespace BGSMod
+	class Items : public BaseFormComponent
 	{
-		namespace Template
-		{
-			class Items : public BaseFormComponent
-			{
-			public:
-				SF_RTTI_VTABLE(BGSMod__Template__Items);
+	public:
+		SF_RTTI_VTABLE(BGSMod__Template__Items);
 
-				virtual ~Items() override;
+		virtual ~Items() override;
 
-				// override (BaseFormComponent)
-				const BSFixedString& GetFormComponentType() const override;  // 01 - { return "BGSMod_Template_Component"; }
-				void                 InitializeDataComponent() override;     // 02
+		// override (BaseFormComponent)
+		const BSFixedString& GetFormComponentType() const override;  // 01 - { return "BGSMod_Template_Component"; }
+		void                 InitializeDataComponent() override;     // 02
 
-				// add
-				virtual void Unk_0B();  // 0B
-				virtual void Unk_0C();  // 0C
-				virtual void Unk_0D();  // 0D
+		// add
+		virtual void Unk_0B();  // 0B
+		virtual void Unk_0C();  // 0C
+		virtual void Unk_0D();  // 0D
 
-				// members
-				BSTArray<void*> unk08;  // 08
-				BSFixedString   unk18;  // 18
-			};
-			static_assert(sizeof(Items) == 0x20);
-		}
-	}
+		// members
+		BSTArray<void*> unk08;  // 08
+		BSFixedString   unk18;  // 18
+	};
+	static_assert(sizeof(Items) == 0x20);
 }

--- a/CommonLibSF/include/RE/B/BSLock.h
+++ b/CommonLibSF/include/RE/B/BSLock.h
@@ -11,7 +11,7 @@ namespace RE
 
 	private:
 		// members
-		volatile std::uint32_t _lock{ 0 };  // 0
+		volatile std::uint32_t _lock{};  // 0
 	};
 	static_assert(sizeof(BSNonReentrantSpinLock) == 0x4);
 
@@ -25,8 +25,8 @@ namespace RE
 
 	private:
 		// members
-		std::uint32_t          _writerThread{ 0 };  // 0
-		volatile std::uint32_t _lock{ 0 };          // 4
+		std::uint32_t          _writerThread{};  // 0
+		volatile std::uint32_t _lock{};          // 4
 	};
 	static_assert(sizeof(BSReadWriteLock) == 0x8);
 
@@ -39,8 +39,8 @@ namespace RE
 
 	private:
 		// members
-		std::uint32_t          _owningThread{ 0 };  // 0
-		volatile std::uint32_t _lock{ 0 };          // 4
+		std::uint32_t          _owningThread{};  // 0
+		volatile std::uint32_t _lock{};          // 4
 	};
 	static_assert(sizeof(BSSpinLock) == 0x8);
 
@@ -101,7 +101,7 @@ namespace RE
 
 	private:
 		// members
-		mutex_type* _lock{ nullptr };  // 00
+		mutex_type* _lock{};  // 00
 	};
 	static_assert(sizeof(BSAutoLock<void*>) == 0x8);
 

--- a/CommonLibSF/include/RE/B/BSReflection.h
+++ b/CommonLibSF/include/RE/B/BSReflection.h
@@ -1,59 +1,56 @@
 #pragma once
 
-namespace RE
+namespace RE::BSReflection
 {
-	namespace BSReflection
+	class IObject
 	{
-		class IObject
-		{
-		public:
-			SF_RTTI_VTABLE(BSReflection__IObject);
+	public:
+		SF_RTTI_VTABLE(BSReflection__IObject);
 
-			virtual void Unk_00();  // 00
-			virtual ~IObject();     // 01
-		};
+		virtual void Unk_00();  // 00
+		virtual ~IObject();     // 01
+	};
 
-		struct TypedData;
+	struct TypedData;
 
-		class IType
-		{
-		public:
-			SF_RTTI(BSReflection__IType);
+	class IType
+	{
+	public:
+		SF_RTTI(BSReflection__IType);
 
-			// add
-			virtual TypedData*  GetZeroed(TypedData* a_dst, void* a_buf) = 0;
-			virtual TypedData*  Copy(TypedData* a_dst, void* a_buf, TypedData* a_src) = 0;
-			virtual TypedData*  Copy2(TypedData* a_dst, void* a_buf, TypedData* a_src) = 0;
-			virtual void        Unk03() = 0;
-			virtual const char* GetName() = 0;
-		};
-		static_assert(sizeof(IType) == 0x08);
+		// add
+		virtual TypedData*  GetZeroed(TypedData* a_dst, void* a_buf) = 0;
+		virtual TypedData*  Copy(TypedData* a_dst, void* a_buf, TypedData* a_src) = 0;
+		virtual TypedData*  Copy2(TypedData* a_dst, void* a_buf, TypedData* a_src) = 0;
+		virtual void        Unk03() = 0;
+		virtual const char* GetName() = 0;
+	};
+	static_assert(sizeof(IType) == 0x08);
 
-		class BasicType : public IType
-		{
-		public:
-			SF_RTTI_VTABLE(BSReflection__BasicType);
+	class BasicType : public IType
+	{
+	public:
+		SF_RTTI_VTABLE(BSReflection__BasicType);
 
-			// members
-			std::uint32_t size;      // 08
-			std::uint16_t size2;     // 0C - repeat of size field?
-			std::uint8_t  unk0E;     // 0E - 00
-			std::uint8_t  unk0F;     // 0F - FF
-			const char*   name;      // 10
-			std::uint8_t  id;        // 18
-			std::uint8_t  isSigned;  // 19
-			std::uint16_t unk1A;     // 1A
-			std::uint32_t unk1C;     // 1C
-		};
-		static_assert(sizeof(BasicType) == 0x20);
+		// members
+		std::uint32_t size;      // 08
+		std::uint16_t size2;     // 0C - repeat of size field?
+		std::uint8_t  unk0E;     // 0E - 00
+		std::uint8_t  unk0F;     // 0F - FF
+		const char*   name;      // 10
+		std::uint8_t  id;        // 18
+		std::uint8_t  isSigned;  // 19
+		std::uint16_t unk1A;     // 1A
+		std::uint32_t unk1C;     // 1C
+	};
+	static_assert(sizeof(BasicType) == 0x20);
 
-		struct TypedData
-		{
-		public:
-			// members
-			IType* type;  // 00
-			void*  data;  // 08
-		};
-		static_assert(sizeof(TypedData) == 0x10);
-	}
+	struct TypedData
+	{
+	public:
+		// members
+		IType* type;  // 00
+		void*  data;  // 08
+	};
+	static_assert(sizeof(TypedData) == 0x10);
 }

--- a/CommonLibSF/include/RE/E/ExtraDataList.h
+++ b/CommonLibSF/include/RE/E/ExtraDataList.h
@@ -26,9 +26,9 @@ namespace RE
 
 	private:
 		// members
-		BSExtraData*  _head{ nullptr };                // 00
+		BSExtraData*  _head{};                // 00
 		BSExtraData** _tail{ std::addressof(_head) };  // 08
-		std::uint8_t* _flags{ nullptr };               // 10
+		std::uint8_t* _flags{};               // 10
 	};
 	static_assert(sizeof(BaseExtraList) == 0x18);
 

--- a/CommonLibSF/include/RE/F/FormTypes.h
+++ b/CommonLibSF/include/RE/F/FormTypes.h
@@ -236,39 +236,33 @@ namespace std
 }
 
 #ifdef FMT_VERSION
-namespace fmt
+template <>
+struct fmt::formatter<RE::FormType>
 {
-	template <>
-	struct formatter<RE::FormType>
+	template <class ParseContext>
+	static constexpr auto parse(ParseContext& a_ctx)
 	{
-		template <class ParseContext>
-		constexpr auto parse(ParseContext& a_ctx)
-		{
-			return a_ctx.begin();
-		}
+		return a_ctx.begin();
+	}
 
-		template <class FormatContext>
-		auto format(const RE::FormType& a_formType, FormatContext& a_ctx)
-		{
-			return fmt::format_to(a_ctx.out(), "{}", FormTypeToString(a_formType));
-		}
-	};
-}
+	template <class FormatContext>
+	auto format(const RE::FormType& a_formType, FormatContext& a_ctx)
+	{
+		return fmt::format_to(a_ctx.out(), "{}", FormTypeToString(a_formType));
+	}
+};
 #endif
 
 #ifdef __cpp_lib_format
-namespace std
+template <class CharT>
+struct std::formatter<RE::FormType, CharT> : std::formatter<std::string_view, CharT>
 {
-	template <class CharT>
-	struct formatter<RE::FormType, CharT> : std::formatter<std::string_view, CharT>
+	template <class FormatContext>
+	auto format(RE::FormType a_formType, FormatContext& a_ctx)
 	{
-		template <class FormatContext>
-		auto format(RE::FormType a_formType, FormatContext& a_ctx)
-		{
-			return formatter<std::string_view, CharT>::format(FormTypeToString(a_formType), a_ctx);
-		}
-	};
-}
+		return formatter<std::string_view, CharT>::format(FormTypeToString(a_formType), a_ctx);
+	}
+};
 #endif
 
 #define SF_FORMTYPE(TYPE) \

--- a/CommonLibSF/include/RE/H/HandlePolicy.h
+++ b/CommonLibSF/include/RE/H/HandlePolicy.h
@@ -1,44 +1,41 @@
 #include "RE/B/BSFixedString.h"
 #include "RE/B/BSIntrusiveRefCounted.h"
 #include "RE/I/IObjectHandlePolicy.h"
-namespace RE
+
+namespace RE::GameScript
 {
-	namespace GameScript
+	struct HandlePolicy :
+		public BSScript::IObjectHandlePolicy  // 00
 	{
+	public:
+		SF_RTTI_VTABLE(GameScript__HandlePolicy);
 
-		struct HandlePolicy :
-			public BSScript::IObjectHandlePolicy  // 00
-		{
-		public:
-			SF_RTTI_VTABLE(GameScript__HandlePolicy);
+		// override (BSScript::IObjectHandlePolicy)
+		bool        HandleIsType(std::uint32_t a_type, std::size_t a_handle) const override;              // 01
+		bool        GetHandleType(std::size_t a_handle, std::uint32_t& a_type) const override;            // 02
+		bool        IsHandleLoaded(std::size_t a_handle) const override;                                  // 03
+		bool        IsHandleObjectAvailable(std::size_t a_handle) const override;                         // 04
+		bool        ShouldAttemptToCleanHandle(std::size_t a_handle) const override;                      // 05
+		std::size_t EmptyHandle() const override { return 0xFFFF00000000; }                               // 06
+		std::size_t GetHandleForObject(std::uint32_t a_type, const void* a_object) const override;        // 07
+		bool        HasParent(std::size_t a_childHandle) const override;                                  // 08
+		std::size_t GetParentHandle(std::size_t a_childHandle) const override;                            // 09
+		std::size_t GetHandleScriptsMovedFrom(std::size_t a_newHandle) const override;                    // 0A
+		std::size_t GetSaveRemappedHandle(std::size_t a_saveHandle) const override;                       // 0B
+		void*       GetObjectForHandle(std::uint32_t a_type, std::size_t a_handle) const override;        // 0C
+		void        PersistHandle(std::size_t a_handle) override;                                         // 0D
+		void        ReleaseHandle(std::size_t a_handle) override;                                         // 0E
+		void        ConvertHandleToString(std::size_t a_handle, BSFixedString& a_string) const override;  // 0F
 
-			// override (BSScript::IObjectHandlePolicy)
-			bool        HandleIsType(std::uint32_t a_type, std::size_t a_handle) const override;              // 01
-			bool        GetHandleType(std::size_t a_handle, std::uint32_t& a_type) const override;            // 02
-			bool        IsHandleLoaded(std::size_t a_handle) const override;                                  // 03
-			bool        IsHandleObjectAvailable(std::size_t a_handle) const override;                         // 04
-			bool        ShouldAttemptToCleanHandle(std::size_t a_handle) const override;                      // 05
-			std::size_t EmptyHandle() const override { return 0xFFFF00000000; }                               // 06
-			std::size_t GetHandleForObject(std::uint32_t a_type, const void* a_object) const override;        // 07
-			bool        HasParent(std::size_t a_childHandle) const override;                                  // 08
-			std::size_t GetParentHandle(std::size_t a_childHandle) const override;                            // 09
-			std::size_t GetHandleScriptsMovedFrom(std::size_t a_newHandle) const override;                    // 0A
-			std::size_t GetSaveRemappedHandle(std::size_t a_saveHandle) const override;                       // 0B
-			void*       GetObjectForHandle(std::uint32_t a_type, std::size_t a_handle) const override;        // 0C
-			void        PersistHandle(std::size_t a_handle) override;                                         // 0D
-			void        ReleaseHandle(std::size_t a_handle) override;                                         // 0E
-			void        ConvertHandleToString(std::size_t a_handle, BSFixedString& a_string) const override;  // 0F
-
-			// members
-			uint64_t                                               unk08;                  // 08
-			BSSpinLock                                             persistLock;            // 10
-			/*BSTHashMap<std::size_t, std::uint32_t>*/ std::byte   persistRefCount[0x30];  // 18
-			uint64_t                                               unk48;                  // 48
-			/*BSTHashMap<std::size_t, bool>*/ std::byte            queuedPromotes[0x30];   // 50
-			uint64_t                                               unk80;                  // 80
-			BSSpinLock                                             remapLock;              // 88
-			/*BSTHashMap<std::uint32_t, std::uint32_t>*/ std::byte changedFormIDs[0x30];   // 90
-		};
-		static_assert(sizeof(HandlePolicy) == 0xC0);
-	}
+		// members
+		uint64_t                                               unk08;                  // 08
+		BSSpinLock                                             persistLock;            // 10
+		/*BSTHashMap<std::size_t, std::uint32_t>*/ std::byte   persistRefCount[0x30];  // 18
+		uint64_t                                               unk48;                  // 48
+		/*BSTHashMap<std::size_t, bool>*/ std::byte            queuedPromotes[0x30];   // 50
+		uint64_t                                               unk80;                  // 80
+		BSSpinLock                                             remapLock;              // 88
+		/*BSTHashMap<std::uint32_t, std::uint32_t>*/ std::byte changedFormIDs[0x30];   // 90
+	};
+	static_assert(sizeof(HandlePolicy) == 0xC0);
 }

--- a/CommonLibSF/include/RE/I/IComplexType.h
+++ b/CommonLibSF/include/RE/I/IComplexType.h
@@ -3,26 +3,23 @@
 #include "RE/B/BSIntrusiveRefCounted.h"
 #include "RE/T/TypeInfo.h"
 
-namespace RE
+namespace RE::BSScript
 {
-	namespace BSScript
+	class TypeInfo;
+
+	class __declspec(novtable) IComplexType :
+		public BSIntrusiveRefCounted  // 08
 	{
-		class TypeInfo;
+	public:
+		SF_RTTI_VTABLE(BSScript__IComplexType);
 
-		class __declspec(novtable) IComplexType :
-			public BSIntrusiveRefCounted  // 08
-		{
-		public:
-			SF_RTTI_VTABLE(BSScript__IComplexType);
+		// TODO: Verify that setting this to default doesn't fuck everything up
+		virtual ~IComplexType() = default;  // 00
 
-			// TODO: Verify that setting this to default doesn't fuck everything up
-			virtual ~IComplexType() = default;  // 00
+		// add
+		virtual TypeInfo::RawType GetRawType() const = 0;  // 01
 
-			// add
-			virtual TypeInfo::RawType GetRawType() const = 0;  // 01
-
-			[[nodiscard]] bool IsObject() const { return GetRawType() == TypeInfo::RawType::kObject; }
-		};
-		static_assert(sizeof(IComplexType) == 0x10);
-	}
+		[[nodiscard]] bool IsObject() const { return GetRawType() == TypeInfo::RawType::kObject; }
+	};
+	static_assert(sizeof(IComplexType) == 0x10);
 }

--- a/CommonLibSF/include/RE/I/IFunction.h
+++ b/CommonLibSF/include/RE/I/IFunction.h
@@ -3,59 +3,56 @@
 #include "RE/B/BSFixedString.h"
 #include "RE/B/BSIntrusiveRefCounted.h"
 
-namespace RE
+namespace RE::BSScript
 {
-	namespace BSScript
+	namespace Internal
 	{
-		namespace Internal
-		{
-			class VirtualMachine;
-		}
-
-		class VMClassInfo;
-		class VMClassRegistry;
-		class VMState;
-		class VMValue;
-
-		class IFunction
-		{
-		public:
-			IFunction() {}
-			virtual ~IFunction() {}
-
-			struct Unk13
-			{
-				std::uint64_t unk00;
-				std::uint32_t unk08;
-			};
-
-			virtual BSFixedString* GetName(void) = 0;
-			virtual BSFixedString* GetClassName(void) = 0;
-			virtual BSFixedString* GetStateName(void) = 0;
-			virtual std::uint64_t* GetReturnType(std::uint64_t* a_dst) = 0;
-			virtual std::uint64_t  GetNumParams(void) = 0;
-			virtual std::uint64_t* GetParam(std::uint32_t a_idx, BSFixedString* a_nameOut, std::uint64_t* a_typeOut) = 0;
-			virtual std::uint64_t  GetNumParams2(void) = 0;
-			virtual bool           IsNative(void) = 0;
-			virtual bool           IsStatic(void) = 0;
-			virtual bool           Unk_0A(void) = 0;
-			virtual std::uint32_t  Unk_0B(void) = 0;
-			virtual std::uint32_t  GetUserFlags(void) = 0;
-			virtual BSFixedString* GetDocString(void) = 0;
-			virtual void           Unk_0E(std::uint32_t a_unk) = 0;
-			virtual std::uint32_t  Invoke(std::uint64_t a_unk0, std::uint64_t a_unk1, VMClassRegistry* a_registry, VMState* a_unk3) = 0;
-			virtual BSFixedString* Unk_10(void) = 0;  // file/line number?
-			virtual bool           Unk_11(std::uint32_t a_unk0, std::uint32_t* a_unk1) = 0;
-			virtual std::uint64_t* Unk_12(std::uint64_t* a_out) = 0;                        // new, might be type reflection
-			virtual Unk13          Unk_13(Unk13* a_out) = 0;                                // new, might be type reflection
-			virtual bool           GetParamInfo(std::uint32_t a_idx, void* a_out) = 0;      // param list stuff
-			virtual void*          Unk_15(std::uint64_t a_arg0, std::uint64_t a_arg1) = 0;  // param list stuff, loop
-			virtual bool           GetUnk41(void) = 0;
-			virtual void           SetUnk41(bool a_arg) = 0;
-
-			// members
-			BSIntrusiveRefCounted refCount;  // 08
-		};
-		static_assert(sizeof(IFunction) == 0x10);
+		class VirtualMachine;
 	}
+
+	class VMClassInfo;
+	class VMClassRegistry;
+	class VMState;
+	class VMValue;
+
+	class IFunction
+	{
+	public:
+		IFunction() {}
+		virtual ~IFunction() {}
+
+		struct Unk13
+		{
+			std::uint64_t unk00;
+			std::uint32_t unk08;
+		};
+
+		virtual BSFixedString* GetName(void) = 0;
+		virtual BSFixedString* GetClassName(void) = 0;
+		virtual BSFixedString* GetStateName(void) = 0;
+		virtual std::uint64_t* GetReturnType(std::uint64_t* a_dst) = 0;
+		virtual std::uint64_t  GetNumParams(void) = 0;
+		virtual std::uint64_t* GetParam(std::uint32_t a_idx, BSFixedString* a_nameOut, std::uint64_t* a_typeOut) = 0;
+		virtual std::uint64_t  GetNumParams2(void) = 0;
+		virtual bool           IsNative(void) = 0;
+		virtual bool           IsStatic(void) = 0;
+		virtual bool           Unk_0A(void) = 0;
+		virtual std::uint32_t  Unk_0B(void) = 0;
+		virtual std::uint32_t  GetUserFlags(void) = 0;
+		virtual BSFixedString* GetDocString(void) = 0;
+		virtual void           Unk_0E(std::uint32_t a_unk) = 0;
+		virtual std::uint32_t  Invoke(std::uint64_t a_unk0, std::uint64_t a_unk1, VMClassRegistry* a_registry, VMState* a_unk3) = 0;
+		virtual BSFixedString* Unk_10(void) = 0;  // file/line number?
+		virtual bool           Unk_11(std::uint32_t a_unk0, std::uint32_t* a_unk1) = 0;
+		virtual std::uint64_t* Unk_12(std::uint64_t* a_out) = 0;                        // new, might be type reflection
+		virtual Unk13          Unk_13(Unk13* a_out) = 0;                                // new, might be type reflection
+		virtual bool           GetParamInfo(std::uint32_t a_idx, void* a_out) = 0;      // param list stuff
+		virtual void*          Unk_15(std::uint64_t a_arg0, std::uint64_t a_arg1) = 0;  // param list stuff, loop
+		virtual bool           GetUnk41(void) = 0;
+		virtual void           SetUnk41(bool a_arg) = 0;
+
+		// members
+		BSIntrusiveRefCounted refCount;  // 08
+	};
+	static_assert(sizeof(IFunction) == 0x10);
 }

--- a/CommonLibSF/include/RE/I/IObjectHandlePolicy.h
+++ b/CommonLibSF/include/RE/I/IObjectHandlePolicy.h
@@ -1,39 +1,32 @@
 #pragma once
 
 #include "RE/B/BSFixedString.h"
-#include "RE/B/BSLock.h"
-#include "RE/B/BSTArray.h"
-#include "RE/B/BSTEvent.h"
-#include "RE/B/BSTSmartPointer.h"
 
-namespace RE
+namespace RE::BSScript
 {
-	namespace BSScript
+	struct IObjectHandlePolicy
 	{
-		struct IObjectHandlePolicy
-		{
-		public:
-			SF_RTTI_VTABLE(BSScript__IObjectHandlePolicy);
+	public:
+		SF_RTTI_VTABLE(BSScript__IObjectHandlePolicy);
 
-			virtual ~IObjectHandlePolicy() = default;  // 00
+		virtual ~IObjectHandlePolicy() = default;  // 00
 
-			// add
-			virtual bool        HandleIsType(std::uint32_t a_type, std::size_t a_handle) const = 0;              // 01
-			virtual bool        GetHandleType(std::size_t a_handle, std::uint32_t& a_type) const = 0;            // 02
-			virtual bool        IsHandleLoaded(std::size_t a_handle) const = 0;                                  // 03
-			virtual bool        IsHandleObjectAvailable(std::size_t a_handle) const = 0;                         // 04
-			virtual bool        ShouldAttemptToCleanHandle(std::size_t a_handle) const = 0;                      // 05
-			virtual std::size_t EmptyHandle() const = 0;                                                         // 06
-			virtual std::size_t GetHandleForObject(std::uint32_t a_type, const void* a_object) const = 0;        // 07
-			virtual bool        HasParent(std::size_t a_childHandle) const = 0;                                  // 08
-			virtual std::size_t GetParentHandle(std::size_t a_childHandle) const = 0;                            // 09
-			virtual std::size_t GetHandleScriptsMovedFrom(std::size_t a_newHandle) const = 0;                    // 0A
-			virtual std::size_t GetSaveRemappedHandle(std::size_t a_saveHandle) const = 0;                       // 0B
-			virtual void*       GetObjectForHandle(std::uint32_t a_type, std::size_t a_handle) const = 0;        // 0C
-			virtual void        PersistHandle(std::size_t a_handle) = 0;                                         // 0D
-			virtual void        ReleaseHandle(std::size_t a_handle) = 0;                                         // 0E
-			virtual void        ConvertHandleToString(std::size_t a_handle, BSFixedString& a_string) const = 0;  // 0F
-		};
-		static_assert(sizeof(IObjectHandlePolicy) == 0x8);
-	}
+		// add
+		virtual bool        HandleIsType(std::uint32_t a_type, std::size_t a_handle) const = 0;              // 01
+		virtual bool        GetHandleType(std::size_t a_handle, std::uint32_t& a_type) const = 0;            // 02
+		virtual bool        IsHandleLoaded(std::size_t a_handle) const = 0;                                  // 03
+		virtual bool        IsHandleObjectAvailable(std::size_t a_handle) const = 0;                         // 04
+		virtual bool        ShouldAttemptToCleanHandle(std::size_t a_handle) const = 0;                      // 05
+		virtual std::size_t EmptyHandle() const = 0;                                                         // 06
+		virtual std::size_t GetHandleForObject(std::uint32_t a_type, const void* a_object) const = 0;        // 07
+		virtual bool        HasParent(std::size_t a_childHandle) const = 0;                                  // 08
+		virtual std::size_t GetParentHandle(std::size_t a_childHandle) const = 0;                            // 09
+		virtual std::size_t GetHandleScriptsMovedFrom(std::size_t a_newHandle) const = 0;                    // 0A
+		virtual std::size_t GetSaveRemappedHandle(std::size_t a_saveHandle) const = 0;                       // 0B
+		virtual void*       GetObjectForHandle(std::uint32_t a_type, std::size_t a_handle) const = 0;        // 0C
+		virtual void        PersistHandle(std::size_t a_handle) = 0;                                         // 0D
+		virtual void        ReleaseHandle(std::size_t a_handle) = 0;                                         // 0E
+		virtual void        ConvertHandleToString(std::size_t a_handle, BSFixedString& a_string) const = 0;  // 0F
+	};
+	static_assert(sizeof(IObjectHandlePolicy) == 0x8);
 }

--- a/CommonLibSF/include/RE/I/IVMObjectBindInterface.h
+++ b/CommonLibSF/include/RE/I/IVMObjectBindInterface.h
@@ -3,30 +3,27 @@
 #include "RE/B/BSFixedString.h"
 #include "RE/B/BSTSmartPointer.h"
 
-namespace RE
+namespace RE::BSScript
 {
-	namespace BSScript
+	class Object;
+
+	struct __declspec(novtable) IVMObjectBindInterface
 	{
-		class Object;
+	public:
+		SF_RTTI_VTABLE(BSScript__IVMObjectBindInterface);
+		virtual ~IVMObjectBindInterface();  // 00
 
-		struct __declspec(novtable) IVMObjectBindInterface
-		{
-		public:
-			SF_RTTI_VTABLE(BSScript__IVMObjectBindInterface);
-			virtual ~IVMObjectBindInterface();  // 00
-
-			// add
-			[[nodiscard]] virtual std::uint64_t GetBoundHandle(const BSTSmartPointer<Object>& a_objPtr) const = 0;                                                                   // 01
-			virtual void                        TypeCanBeBound(const BSFixedString& a_className, std::uint64_t a_handle) = 0;                                                        // 02
-			virtual void                        BindObject(BSTSmartPointer<Object>& a_objPtr, std::uint64_t a_handle, bool a_conditional) = 0;                                       // 03
-			virtual void                        HandleLoadedBinding(BSTSmartPointer<Object>& a_objPtr, std::uint64_t a_handle, bool a_conditional) = 0;                              // 04
-			virtual void                        RemoveAllBoundObjects(std::uint64_t a_handle) = 0;                                                                                   // 05
-			virtual void                        RemoveAllDiskLoadedBoundObjects(std::uint64_t a_handle) = 0;                                                                         // 06
-			virtual void                        HandleCObjectDeletion(std::uint64_t a_handle) = 0;                                                                                   // 07
-			virtual void                        UnbindObject(const BSTSmartPointer<Object>& a_objPtr) = 0;                                                                           // 08
-			virtual bool                        CreateObjectWithProperties(const BSFixedString& a_className, std::uint32_t a_numProperties, BSTSmartPointer<Object>& a_objPtr) = 0;  // 09
-			virtual bool                        InitObjectProperties(BSTSmartPointer<Object>& a_objPtr, void* a_property, bool a_arg3) = 0;                                          // 0A
-		};
-		static_assert(sizeof(IVMObjectBindInterface) == 0x8);
-	}
+		// add
+		[[nodiscard]] virtual std::uint64_t GetBoundHandle(const BSTSmartPointer<Object>& a_objPtr) const = 0;                                                                   // 01
+		virtual void                        TypeCanBeBound(const BSFixedString& a_className, std::uint64_t a_handle) = 0;                                                        // 02
+		virtual void                        BindObject(BSTSmartPointer<Object>& a_objPtr, std::uint64_t a_handle, bool a_conditional) = 0;                                       // 03
+		virtual void                        HandleLoadedBinding(BSTSmartPointer<Object>& a_objPtr, std::uint64_t a_handle, bool a_conditional) = 0;                              // 04
+		virtual void                        RemoveAllBoundObjects(std::uint64_t a_handle) = 0;                                                                                   // 05
+		virtual void                        RemoveAllDiskLoadedBoundObjects(std::uint64_t a_handle) = 0;                                                                         // 06
+		virtual void                        HandleCObjectDeletion(std::uint64_t a_handle) = 0;                                                                                   // 07
+		virtual void                        UnbindObject(const BSTSmartPointer<Object>& a_objPtr) = 0;                                                                           // 08
+		virtual bool                        CreateObjectWithProperties(const BSFixedString& a_className, std::uint32_t a_numProperties, BSTSmartPointer<Object>& a_objPtr) = 0;  // 09
+		virtual bool                        InitObjectProperties(BSTSmartPointer<Object>& a_objPtr, void* a_property, bool a_arg3) = 0;                                          // 0A
+	};
+	static_assert(sizeof(IVMObjectBindInterface) == 0x8);
 }

--- a/CommonLibSF/include/RE/N/NativeFunction.h
+++ b/CommonLibSF/include/RE/N/NativeFunction.h
@@ -2,34 +2,31 @@
 
 #include "RE/N/NativeFunctionBase.h"
 
-namespace RE
+namespace RE::BSScript
 {
-	namespace BSScript
+	class NativeFunction : public NF_util::NativeFunctionBase
 	{
-		class NativeFunction : public NF_util::NativeFunctionBase
+	public:
+		NativeFunction() = delete;
+		NativeFunction(const char* a_name, const char* a_className, bool a_isStatic, std::uint32_t a_numParams)
 		{
-		public:
-			NativeFunction() = delete;
-			NativeFunction(const char* a_name, const char* a_className, bool a_isStatic, std::uint32_t a_numParams)
-			{
-				using func_t = std::add_pointer_t<NativeFunction*(NativeFunction*, const char*, const char*, bool, std::uint32_t)>;
-				REL::Relocation<func_t> func{ REL::ID(196396) };
-				func(this, a_name, a_className, a_isStatic, a_numParams);
-			}
+			using func_t = std::add_pointer_t<NativeFunction*(NativeFunction*, const char*, const char*, bool, std::uint32_t)>;
+			REL::Relocation<func_t> func{ REL::ID(196396) };
+			func(this, a_name, a_className, a_isStatic, a_numParams);
+		}
 
-			virtual ~NativeFunction()
-			{
-				using func_t = std::add_pointer_t<void(NativeFunction*)>;
-				REL::Relocation<func_t> func{ REL::ID(196398) };
-				func(this);
-			}
+		virtual ~NativeFunction()
+		{
+			using func_t = std::add_pointer_t<void(NativeFunction*)>;
+			REL::Relocation<func_t> func{ REL::ID(196398) };
+			func(this);
+		}
 
-			virtual bool HasCallback(void) override { return _callback != 0; }
-			virtual bool Run(VMValue* a_baseValue, VMClassRegistry* a_registry, std::uint32_t a_arg2, VMValue* a_resultValue, VMState* a_state) = 0;
+		virtual bool HasCallback(void) override { return _callback != 0; }
+		virtual bool Run(VMValue* a_baseValue, VMClassRegistry* a_registry, std::uint32_t a_arg2, VMValue* a_resultValue, VMState* a_state) = 0;
 
-		protected:
-			void* _callback;  // 50
-		};
-		static_assert(sizeof(NativeFunction) == 0x60);
-	}
+	protected:
+		void* _callback;  // 50
+	};
+	static_assert(sizeof(NativeFunction) == 0x60);
 }

--- a/CommonLibSF/include/RE/N/NativeFunctionBase.h
+++ b/CommonLibSF/include/RE/N/NativeFunctionBase.h
@@ -2,136 +2,133 @@
 
 #include "RE/I/IFunction.h"
 
-namespace RE
+namespace RE::BSScript
 {
-	namespace BSScript
+	namespace Internal
 	{
-		namespace Internal
-		{
-			class VirtualMachine;
-		}
+		class VirtualMachine;
+	}
 
-		class StackFrame;
-		class Variable;
+	class StackFrame;
+	class Variable;
 
-		namespace NF_util
+	namespace NF_util
+	{
+		class NativeFunctionBase : public IFunction
 		{
-			class NativeFunctionBase : public IFunction
+		public:
+			SF_RTTI_VTABLE(BSScript__NF_util__NativeFunctionBase);
+
+			NativeFunctionBase() {}
+			virtual ~NativeFunctionBase() {}
+
+			struct alignas(0x10) ParameterInfo
 			{
 			public:
-				SF_RTTI_VTABLE(BSScript__NF_util__NativeFunctionBase);
-
-				NativeFunctionBase() {}
-				virtual ~NativeFunctionBase() {}
-
-				struct alignas(0x10) ParameterInfo
+				struct Entry
 				{
 				public:
-					struct Entry
-					{
-					public:
-						// members
-						BSFixedString name;  // 00
-
-						union
-						{
-							std::uint64_t type;     // 08 - shared with VMValue::type
-							VMClassInfo*  typePtr;  // 08
-						};
-					};
-
 					// members
-					Entry*        data;       // 00 length = numParams + unk0A
-					std::uint16_t numParams;  // 08
-					std::uint16_t unk0A;      // 0A
+					BSFixedString name;  // 00
+
+					union
+					{
+						std::uint64_t type;     // 08 - shared with VMValue::type
+						VMClassInfo*  typePtr;  // 08
+					};
 				};
-				static_assert(sizeof(ParameterInfo) == 0x10);
 
-				virtual BSFixedString* GetName(void) override { return &_name; }
-				virtual BSFixedString* GetClassName(void) override { return &_className; }
-				virtual BSFixedString* GetStateName(void) override { return &_stateName; }
-				virtual std::uint64_t* GetReturnType(std::uint64_t* a_dst) override
-				{
-					*a_dst = _retType;
-					return a_dst;
-				}
-				virtual std::uint64_t  GetNumParams(void) override { return _params.numParams; }
-				virtual std::uint64_t* GetParam(std::uint32_t a_idx, BSFixedString* a_nameOut, std::uint64_t* a_typeOut)
-				{
-					using func_t = std::add_pointer_t<std::uint64_t*(ParameterInfo*, std::uint32_t, BSFixedString*, std::uint64_t*)>;
-					REL::Relocation<func_t> func{ ID::BSScript::Internal::NF_util::NativeFunctionBase::GetParam };
-					return func(&_params, a_idx, a_nameOut, a_typeOut);
-				}
-				virtual std::uint64_t  GetNumParams2(void) override { return _params.unk0A; }
-				virtual bool           IsNative(void) override { return true; }
-				virtual bool           IsStatic(void) override { return _isStatic; }
-				virtual bool           Unk_0A(void) override { return false; }
-				virtual std::uint32_t  Unk_0B(void) override { return 0; }
-				virtual std::uint32_t  GetUserFlags(void) override { return _userFlags; }
-				virtual BSFixedString* GetDocString(void) override { return &_docString; }
-				virtual void           Unk_0E(std::uint32_t a_unk) override { (void)a_unk; }  // always nop?
-				virtual std::uint32_t  Invoke(std::uint64_t a_unk0, std::uint64_t a_unk1, VMClassRegistry* a_registry, VMState* a_unk3) override
-				{
-					using func_t = decltype(&NativeFunctionBase::Invoke);
-					REL::Relocation<func_t> func{ ID::BSScript::Internal::NF_util::NativeFunctionBase::Invoke };
-					return func(this, a_unk0, a_unk1, a_registry, a_unk3);
-				}
-				virtual BSFixedString* Unk_10(void) override
-				{
-					using func_t = decltype(&NativeFunctionBase::Unk_10);
-					REL::Relocation<func_t> func{ ID::BSScript::Internal::NF_util::NativeFunctionBase::Unk_10 };
-					return func(this);
-				}
-				virtual bool Unk_11(std::uint32_t a_unk0, std::uint32_t* a_unk1) override
-				{
-					(void)a_unk0;
-					*a_unk1 = 0;
-					return false;
-				}
-				virtual std::uint64_t* Unk_12(std::uint64_t* a_out) override
-				{
-					*a_out = 0;
-					// a_out[4] = 0; // as std::uint8_t?
-
-					return a_out;
-				}
-				virtual Unk13 Unk_13(Unk13* a_out) override
-				{
-					a_out->unk00 = 0;
-					a_out->unk08 = 0;
-					// a_out[8] = 0; // as std::uint8_t?
-				}
-				virtual bool GetParamInfo(std::uint32_t a_idx, void* a_out) override
-				{
-					using func_t = decltype(&NativeFunctionBase::GetParamInfo);
-					REL::Relocation<func_t> func{ ID::BSScript::Internal::NF_util::NativeFunctionBase::GetParamInfo };
-					return func(this, a_idx, a_out);
-				}
-				virtual void* Unk_15(std::uint64_t a_arg0, std::uint64_t a_arg1)
-				{
-					using func_t = decltype(&NativeFunctionBase::Unk_15);
-					REL::Relocation<func_t> func{ ID::BSScript::Internal::NF_util::NativeFunctionBase::Unk_15 };
-					return func(this, a_arg0, a_arg1);
-				}
-				virtual bool GetUnk41(void) override { return _isCallableFromTasklet; }
-				virtual void SetUnk41(bool a_arg) override { _isCallableFromTasklet = a_arg; }
-				virtual bool HasCallback() = 0;
-				virtual void Run() = 0;
-
-			protected:
-				BSFixedString _name;                     // 10
-				BSFixedString _className;                // 18
-				BSFixedString _stateName{ "" };          // 20
-				std::uint64_t _retType;                  // 28 TypeInfo
-				ParameterInfo _params;                   // 30
-				bool          _isStatic;                 // 40
-				bool          _isCallableFromTasklet{};  // 41
-				bool          _isLatent{};               // 42
-				std::uint8_t  _pad43;                    // 43
-				std::uint32_t _userFlags{};              // 44
-				BSFixedString _docString;                // 48
+				// members
+				Entry*        data;       // 00 length = numParams + unk0A
+				std::uint16_t numParams;  // 08
+				std::uint16_t unk0A;      // 0A
 			};
-			static_assert(sizeof(NativeFunctionBase) == 0x50);
-		}
+			static_assert(sizeof(ParameterInfo) == 0x10);
+
+			virtual BSFixedString* GetName(void) override { return &_name; }
+			virtual BSFixedString* GetClassName(void) override { return &_className; }
+			virtual BSFixedString* GetStateName(void) override { return &_stateName; }
+			virtual std::uint64_t* GetReturnType(std::uint64_t* a_dst) override
+			{
+				*a_dst = _retType;
+				return a_dst;
+			}
+			virtual std::uint64_t  GetNumParams(void) override { return _params.numParams; }
+			virtual std::uint64_t* GetParam(std::uint32_t a_idx, BSFixedString* a_nameOut, std::uint64_t* a_typeOut)
+			{
+				using func_t = std::add_pointer_t<std::uint64_t*(ParameterInfo*, std::uint32_t, BSFixedString*, std::uint64_t*)>;
+				REL::Relocation<func_t> func{ ID::BSScript::Internal::NF_util::NativeFunctionBase::GetParam };
+				return func(&_params, a_idx, a_nameOut, a_typeOut);
+			}
+			virtual std::uint64_t  GetNumParams2(void) override { return _params.unk0A; }
+			virtual bool           IsNative(void) override { return true; }
+			virtual bool           IsStatic(void) override { return _isStatic; }
+			virtual bool           Unk_0A(void) override { return false; }
+			virtual std::uint32_t  Unk_0B(void) override { return 0; }
+			virtual std::uint32_t  GetUserFlags(void) override { return _userFlags; }
+			virtual BSFixedString* GetDocString(void) override { return &_docString; }
+			virtual void           Unk_0E(std::uint32_t a_unk) override { (void)a_unk; }  // always nop?
+			virtual std::uint32_t  Invoke(std::uint64_t a_unk0, std::uint64_t a_unk1, VMClassRegistry* a_registry, VMState* a_unk3) override
+			{
+				using func_t = decltype(&NativeFunctionBase::Invoke);
+				REL::Relocation<func_t> func{ ID::BSScript::Internal::NF_util::NativeFunctionBase::Invoke };
+				return func(this, a_unk0, a_unk1, a_registry, a_unk3);
+			}
+			virtual BSFixedString* Unk_10(void) override
+			{
+				using func_t = decltype(&NativeFunctionBase::Unk_10);
+				REL::Relocation<func_t> func{ ID::BSScript::Internal::NF_util::NativeFunctionBase::Unk_10 };
+				return func(this);
+			}
+			virtual bool Unk_11(std::uint32_t a_unk0, std::uint32_t* a_unk1) override
+			{
+				(void)a_unk0;
+				*a_unk1 = 0;
+				return false;
+			}
+			virtual std::uint64_t* Unk_12(std::uint64_t* a_out) override
+			{
+				*a_out = 0;
+				// a_out[4] = 0; // as std::uint8_t?
+
+				return a_out;
+			}
+			virtual Unk13 Unk_13(Unk13* a_out) override
+			{
+				a_out->unk00 = 0;
+				a_out->unk08 = 0;
+				// a_out[8] = 0; // as std::uint8_t?
+			}
+			virtual bool GetParamInfo(std::uint32_t a_idx, void* a_out) override
+			{
+				using func_t = decltype(&NativeFunctionBase::GetParamInfo);
+				REL::Relocation<func_t> func{ ID::BSScript::Internal::NF_util::NativeFunctionBase::GetParamInfo };
+				return func(this, a_idx, a_out);
+			}
+			virtual void* Unk_15(std::uint64_t a_arg0, std::uint64_t a_arg1)
+			{
+				using func_t = decltype(&NativeFunctionBase::Unk_15);
+				REL::Relocation<func_t> func{ ID::BSScript::Internal::NF_util::NativeFunctionBase::Unk_15 };
+				return func(this, a_arg0, a_arg1);
+			}
+			virtual bool GetUnk41(void) override { return _isCallableFromTasklet; }
+			virtual void SetUnk41(bool a_arg) override { _isCallableFromTasklet = a_arg; }
+			virtual bool HasCallback() = 0;
+			virtual void Run() = 0;
+
+		protected:
+			BSFixedString _name;                     // 10
+			BSFixedString _className;                // 18
+			BSFixedString _stateName{ "" };          // 20
+			std::uint64_t _retType;                  // 28 TypeInfo
+			ParameterInfo _params;                   // 30
+			bool          _isStatic;                 // 40
+			bool          _isCallableFromTasklet{};  // 41
+			bool          _isLatent{};               // 42
+			std::uint8_t  _pad43;                    // 43
+			std::uint32_t _userFlags{};              // 44
+			BSFixedString _docString;                // 48
+		};
+		static_assert(sizeof(NativeFunctionBase) == 0x50);
 	}
 }

--- a/CommonLibSF/include/RE/O/Object.h
+++ b/CommonLibSF/include/RE/O/Object.h
@@ -1,97 +1,90 @@
 #pragma once
 
-#include "RE/B/BSContainer.h"
 #include "RE/B/BSFixedString.h"
-#include "RE/B/BSLock.h"
-#include "RE/B/BSTArray.h"
-#include "RE/B/BSTEvent.h"
 #include "RE/B/BSTSmartPointer.h"
 #include "RE/I/IObjectHandlePolicy.h"
 #include "RE/M/MemoryManager.h"
 #include "RE/O/ObjectTypeInfo.h"
 
-namespace RE
+namespace RE::BSScript
 {
-	namespace BSScript
+	class ObjectTypeInfo;
+	class Variable;
+
+	class Object
 	{
-		class ObjectTypeInfo;
-		class Variable;
-
-		class Object
+	public:
+		void dtor()
 		{
-		public:
-			void dtor()
-			{
-				using func_t = decltype(&Object::dtor);
-				REL::Relocation<func_t> func{ ID::BSScript::Object::dtor };
-				return func(this);
-			}
+			using func_t = decltype(&Object::dtor);
+			REL::Relocation<func_t> func{ ID::BSScript::Object::dtor };
+			return func(this);
+		}
 
-			~Object()
-			{
-				dtor();
-			}
+		~Object()
+		{
+			dtor();
+		}
 
-			Object* ctor(const BSTSmartPointer<ObjectTypeInfo>& a_type, const IObjectHandlePolicy& a_handlePolicy, std::uint32_t a_numProperties)
-			{
-				using func_t = decltype(&Object::ctor);
-				REL::Relocation<func_t> func{ ID::BSScript::Object::ctor };
-				return func(this, a_type, a_handlePolicy, a_numProperties);
-			}
+		Object* ctor(const BSTSmartPointer<ObjectTypeInfo>& a_type, const IObjectHandlePolicy& a_handlePolicy, std::uint32_t a_numProperties)
+		{
+			using func_t = decltype(&Object::ctor);
+			REL::Relocation<func_t> func{ ID::BSScript::Object::ctor };
+			return func(this, a_type, a_handlePolicy, a_numProperties);
+		}
 
-			Object(const BSTSmartPointer<ObjectTypeInfo>& a_type, const IObjectHandlePolicy& a_handlePolicy, std::uint32_t a_numProperties)
-			{
-				ctor(a_type, a_handlePolicy, a_numProperties);
-			}
+		Object(const BSTSmartPointer<ObjectTypeInfo>& a_type, const IObjectHandlePolicy& a_handlePolicy, std::uint32_t a_numProperties)
+		{
+			ctor(a_type, a_handlePolicy, a_numProperties);
+		}
 
-			Object() = delete;
+		Object() = delete;
 
-			[[nodiscard]] constexpr bool IsConstructed() const noexcept { return static_cast<bool>(constructed); }
-			[[nodiscard]] constexpr bool IsInitialized() const noexcept { return static_cast<bool>(initialized); }
-			[[nodiscard]] constexpr bool IsValid() const noexcept { return static_cast<bool>(valid); }
+		[[nodiscard]] constexpr bool IsConstructed() const noexcept { return static_cast<bool>(constructed); }
+		[[nodiscard]] constexpr bool IsInitialized() const noexcept { return static_cast<bool>(initialized); }
+		[[nodiscard]] constexpr bool IsValid() const noexcept { return static_cast<bool>(valid); }
 
-			[[nodiscard]] std::uint32_t DecRef() const
-			{
-				using func_t = decltype(&Object::DecRef);
-				REL::Relocation<func_t> func{ ID::BSScript::Object::DecRef };
-				return func(this);
-			}
+		[[nodiscard]] std::uint32_t DecRef() const
+		{
+			using func_t = decltype(&Object::DecRef);
+			REL::Relocation<func_t> func{ ID::BSScript::Object::DecRef };
+			return func(this);
+		}
 
-			[[nodiscard]] std::size_t GetHandle() const
-			{
-				using func_t = decltype(&Object::GetHandle);
-				REL::Relocation<func_t> func{ ID::BSScript::Object::GetHandle };
-				return func(this);
-			}
+		[[nodiscard]] std::size_t GetHandle() const
+		{
+			using func_t = decltype(&Object::GetHandle);
+			REL::Relocation<func_t> func{ ID::BSScript::Object::GetHandle };
+			return func(this);
+		}
 
-			void IncRef() const
-			{
-				using func_t = decltype(&Object::IncRef);
-				REL::Relocation<func_t> func{ ID::BSScript::Object::IncRef };
-				return func(this);
-			}
+		void IncRef() const
+		{
+			using func_t = decltype(&Object::IncRef);
+			REL::Relocation<func_t> func{ ID::BSScript::Object::IncRef };
+			return func(this);
+		}
 
-			SF_HEAP_REDEFINE_NEW();
+		SF_HEAP_REDEFINE_NEW();
 
-			// members
-			std::uint16_t                   unk00;                     // 00
-			std::uint16_t                   unk02;                     // 02
-			std::uint32_t                   unk04;                     // 04
-			std::uint64_t                   unk08;                     // 08
-			std::uint32_t                   constructed: 1;            // 10:00
-			std::uint32_t                   initialized: 1;            // 10:01
-			std::uint32_t                   valid: 1;                  // 10:02
-			std::uint32_t                   remainingPropsToInit: 29;  // 10:03
-			std::uint32_t                   unk14;                     // 14
-			std::uint32_t                   unk18;                     // 18
-			std::uint32_t                   unk1C;                     // 1C
-			BSTSmartPointer<ObjectTypeInfo> type;                      // 20
-			BSFixedString                   currentState;              // 28
-			void*                           lockStructure;             // 30
-			IObjectHandlePolicy*            handlePolicy;              // 38
-			std::size_t                     handle;                    // 40
-			std::uint32_t                   refCountAndHandleLock;     // 48
-		};
-		static_assert(sizeof(Object) == 0x50);
-	}
+		// members
+		std::uint16_t                   unk00;                     // 00
+		std::uint16_t                   unk02;                     // 02
+		std::uint32_t                   unk04;                     // 04
+		std::uint64_t                   unk08;                     // 08
+		std::uint32_t                   constructed: 1;            // 10:00
+		std::uint32_t                   initialized: 1;            // 10:01
+		std::uint32_t                   valid: 1;                  // 10:02
+		std::uint32_t                   remainingPropsToInit: 29;  // 10:03
+		std::uint32_t                   unk14;                     // 14
+		std::uint32_t                   unk18;                     // 18
+		std::uint32_t                   unk1C;                     // 1C
+		BSTSmartPointer<ObjectTypeInfo> type;                      // 20
+		BSFixedString                   currentState;              // 28
+		void*                           lockStructure;             // 30
+		IObjectHandlePolicy*            handlePolicy;              // 38
+		std::size_t                     handle;                    // 40
+		std::uint32_t                   refCountAndHandleLock;     // 48
+	};
+	static_assert(sizeof(Object) == 0x50);
 }

--- a/CommonLibSF/include/RE/O/ObjectBindPolicy.h
+++ b/CommonLibSF/include/RE/O/ObjectBindPolicy.h
@@ -79,7 +79,6 @@ namespace RE
 			// TODO: unk28 is likely `BSTHashMap<std::size_t, BSTSmallSharedArray<BSTSmartPointer<BoundScript>>> attachedScripts`, but unsure where exactly it starts
 		};
 		static_assert(sizeof(ObjectBindPolicy) == 0x60);
-
 	}
 
 	namespace GameScript

--- a/CommonLibSF/include/RE/O/ObjectTypeInfo.h
+++ b/CommonLibSF/include/RE/O/ObjectTypeInfo.h
@@ -1,39 +1,34 @@
 #pragma once
 
-#include "RE/B/BSContainer.h"
 #include "RE/B/BSFixedString.h"
-#include "RE/B/BSLock.h"
 #include "RE/B/BSTArray.h"
 #include "RE/B/BSTSmartPointer.h"
 #include "RE/I/IComplexType.h"
-#include "RE/I/IFunction.h"
 #include "RE/P/PropertyGroupInfo.h"
 #include "RE/V/Variable.h"
 
-namespace RE
+namespace RE::BSScript
 {
-	namespace BSScript
+	class IFunction;
+
+	class ObjectTypeInfo :
+		public IComplexType  // 00
 	{
-		class IFunction;
+	public:
+		static constexpr auto RTTI{ RTTI::BSScript__ObjectTypeInfo };
+		static constexpr auto VTABLE{ VTABLE::BSScript__ObjectTypeInfo };
 
-		class ObjectTypeInfo :
-			public IComplexType  // 00
+		enum class LinkValidState : std::uint8_t
 		{
-		public:
-			static constexpr auto RTTI{ RTTI::BSScript__ObjectTypeInfo };
-			static constexpr auto VTABLE{ VTABLE::BSScript__ObjectTypeInfo };
+			kNotLinked,
+			kCurrentlyLinking,
+			kLinkedInvalid,
+			kLinkedValid
+		};
 
-			enum class LinkValidState : std::uint8_t
-			{
-				kNotLinked,
-				kCurrentlyLinking,
-				kLinkedInvalid,
-				kLinkedValid
-			};
-
-			// TODO: the rest of this
-			// CopyFromLinkedData() is located at REL::ID(196219) if someone wants to figure this out
-			/***
+		// TODO: the rest of this
+		// CopyFromLinkedData() is located at REL::ID(196219) if someone wants to figure this out
+		/***
              * This likely has:
              * userFlagCount
              * variableCount
@@ -47,36 +42,34 @@ namespace RE
              * But it's not clear which is which.
              * Also it's not clear if they keep track of variableUserFlagCount or initialState anymore.
             */
-			struct CountData
-			{
-				uint16_t unk00;
-				uint16_t variableCount;
-				uint16_t unk04;
-				uint16_t unk06;
-				uint16_t unk08;
-				uint16_t unk0A;
-				uint16_t unk0C;
-				uint16_t unk0E;
-			};
-
-			// override (IComplexType)
-			virtual TypeInfo::RawType GetRawType() const override { return TypeInfo::RawType::kObject; }  // 01
-
-			// members
-			BSFixedString                                name;            // 10
-			BSTSmartPointer<ObjectTypeInfo>              parentTypeInfo;  // 18
-			BSFixedString                                docString;       // 20
-			BSTArray<BSTSmartPointer<PropertyGroupInfo>> propertyGroups;  // 28
-			CountData                                    countData;       // 38
-			uint64_t                                     unk48;           // 48
-			void*                                        data;            // 50
-			uint32_t                                     unk58;           // 58
-			uint16_t                                     unk5C;           // 5C
-			LinkValidState                               linkedValid;     // 5E
-			uint8_t                                      unk5F;           // 5F
-			bool                                         loaded;          // 60
+		struct CountData
+		{
+			uint16_t unk00;
+			uint16_t variableCount;
+			uint16_t unk04;
+			uint16_t unk06;
+			uint16_t unk08;
+			uint16_t unk0A;
+			uint16_t unk0C;
+			uint16_t unk0E;
 		};
 
-		static_assert(sizeof(ObjectTypeInfo) == 0x68);
-	}
+		// override (IComplexType)
+		virtual TypeInfo::RawType GetRawType() const override { return TypeInfo::RawType::kObject; }  // 01
+
+		// members
+		BSFixedString                                name;            // 10
+		BSTSmartPointer<ObjectTypeInfo>              parentTypeInfo;  // 18
+		BSFixedString                                docString;       // 20
+		BSTArray<BSTSmartPointer<PropertyGroupInfo>> propertyGroups;  // 28
+		CountData                                    countData;       // 38
+		uint64_t                                     unk48;           // 48
+		void*                                        data;            // 50
+		uint32_t                                     unk58;           // 58
+		uint16_t                                     unk5C;           // 5C
+		LinkValidState                               linkedValid;     // 5E
+		uint8_t                                      unk5F;           // 5F
+		bool                                         loaded;          // 60
+	};
+	static_assert(sizeof(ObjectTypeInfo) == 0x68);
 }

--- a/CommonLibSF/include/RE/P/PropertyGroupInfo.h
+++ b/CommonLibSF/include/RE/P/PropertyGroupInfo.h
@@ -4,20 +4,17 @@
 #include "RE/B/BSIntrusiveRefCounted.h"
 #include "RE/B/BSTArray.h"
 
-namespace RE
+namespace RE::BSScript
 {
-	namespace BSScript
+	class PropertyGroupInfo :
+		public BSIntrusiveRefCounted  // 00
 	{
-		class PropertyGroupInfo :
-			public BSIntrusiveRefCounted  // 00
-		{
-		public:
-			// members
-			BSFixedString           groupName;      // 08
-			BSFixedString           docString;      // 10
-			std::uint32_t           userFlags;      // 18
-			BSTArray<BSFixedString> propertyNames;  // 20
-		};
-		static_assert(sizeof(PropertyGroupInfo) == 0x30);
-	}
+	public:
+		// members
+		BSFixedString           groupName;      // 08
+		BSFixedString           docString;      // 10
+		std::uint32_t           userFlags;      // 18
+		BSTArray<BSFixedString> propertyNames;  // 20
+	};
+	static_assert(sizeof(PropertyGroupInfo) == 0x30);
 }

--- a/CommonLibSF/include/RE/P/PropertyTypeInfo.h
+++ b/CommonLibSF/include/RE/P/PropertyTypeInfo.h
@@ -5,31 +5,28 @@
 #include "RE/I/IFunction.h"
 #include "RE/T/TypeInfo.h"
 
-namespace RE
+namespace RE::BSScript
 {
-	namespace BSScript
+	class IFunction;
+
+	struct PropertyTypeInfo
 	{
-		class IFunction;
-
-		struct PropertyTypeInfo
+	public:
+		enum class Permissions
 		{
-		public:
-			enum class Permissions
-			{
-			};
-
-			// members
-			BSFixedString                                parentObjName;  // 00
-			BSFixedString                                propertyName;   // 08
-			TypeInfo                                     type;           // 10
-			stl::enumeration<Permissions, std::uint32_t> permissions;    // 18
-			std::uint32_t                                pad1C;          // 1C
-			BSTSmartPointer<IFunction>                   getFunction;    // 20
-			BSTSmartPointer<IFunction>                   setFunction;    // 28
-			std::uint32_t                                autoVarIndex;   // 30
-			std::uint32_t                                userFlags;      // 34
-			BSFixedString                                docString;      // 38
 		};
-		static_assert(sizeof(PropertyTypeInfo) == 0x40);
-	}
+
+		// members
+		BSFixedString                                parentObjName;  // 00
+		BSFixedString                                propertyName;   // 08
+		TypeInfo                                     type;           // 10
+		stl::enumeration<Permissions, std::uint32_t> permissions;    // 18
+		std::uint32_t                                pad1C;          // 1C
+		BSTSmartPointer<IFunction>                   getFunction;    // 20
+		BSTSmartPointer<IFunction>                   setFunction;    // 28
+		std::uint32_t                                autoVarIndex;   // 30
+		std::uint32_t                                userFlags;      // 34
+		BSFixedString                                docString;      // 38
+	};
+	static_assert(sizeof(PropertyTypeInfo) == 0x40);
 }

--- a/CommonLibSF/include/RE/S/Struct.h
+++ b/CommonLibSF/include/RE/S/Struct.h
@@ -1,35 +1,27 @@
 #pragma once
 
-#include "RE/B/BSContainer.h"
-#include "RE/B/BSFixedString.h"
 #include "RE/B/BSLock.h"
-#include "RE/B/BSTArray.h"
-#include "RE/B/BSTEvent.h"
 #include "RE/B/BSTSmartPointer.h"
-#include "RE/M/MemoryManager.h"
 #include "RE/S/StructTypeInfo.h"
 #include "RE/V/Variable.h"
 
-namespace RE
+namespace RE::BSScript
 {
-	namespace BSScript
+	class StructTypeInfo;
+	class Variable;
+
+	class Struct :
+		public BSIntrusiveRefCounted  // 00
 	{
-		class StructTypeInfo;
-		class Variable;
+	public:
+		~Struct();
 
-		class Struct :
-			public BSIntrusiveRefCounted  // 00
-		{
-		public:
-			~Struct();
-
-			// members
-			BSSpinLock                      structLock;           // 04
-			BSTSmartPointer<StructTypeInfo> type;                 // 10
-			bool                            constructed{ true };  // 18
-			bool                            valid{ false };       // 19
-			Variable                        variables[0];         // 20
-		};
-		static_assert(sizeof(Struct) == 0x20);
-	}
+		// members
+		BSSpinLock                      structLock;           // 04
+		BSTSmartPointer<StructTypeInfo> type;                 // 10
+		bool                            constructed{ true };  // 18
+		bool                            valid{ false };       // 19
+		Variable                        variables[0];         // 20
+	};
+	static_assert(sizeof(Struct) == 0x20);
 }

--- a/CommonLibSF/include/RE/S/StructTypeInfo.h
+++ b/CommonLibSF/include/RE/S/StructTypeInfo.h
@@ -1,66 +1,61 @@
 #pragma once
 
 #include "RE/B/BSFixedString.h"
-#include "RE/B/BSLock.h"
 #include "RE/B/BSTArray.h"
 #include "RE/B/BSTSmartPointer.h"
 #include "RE/I/IComplexType.h"
-#include "RE/M/MemoryManager.h"
 #include "RE/O/ObjectTypeInfo.h"
 #include "RE/T/TypeInfo.h"
 #include "RE/V/Variable.h"
 
-namespace RE
+namespace RE::BSScript
 {
-	namespace BSScript
-	{
-		class IComplexType;
-		class ObjectTypeInfo;
-		class TypeInfo;
-		class Variable;
+	class IComplexType;
+	class ObjectTypeInfo;
+	class TypeInfo;
+	class Variable;
 
-		class __declspec(novtable) StructTypeInfo :
-			public IComplexType  // 00
+	class __declspec(novtable) StructTypeInfo :
+		public IComplexType  // 00
+	{
+	public:
+		static constexpr auto RTTI{ RTTI::BSScript__StructTypeInfo };
+		static constexpr auto VTABLE{ VTABLE::BSScript__StructTypeInfo };
+
+		enum class LinkValidState
+		{
+			kNotLinked,
+			kCurrentlyLinking,
+			kLinkedInvalid,
+			kLinkedValid
+		};
+
+		struct StructVar
 		{
 		public:
-			static constexpr auto RTTI{ RTTI::BSScript__StructTypeInfo };
-			static constexpr auto VTABLE{ VTABLE::BSScript__StructTypeInfo };
-
-			enum class LinkValidState
-			{
-				kNotLinked,
-				kCurrentlyLinking,
-				kLinkedInvalid,
-				kLinkedValid
-			};
-
-			struct StructVar
-			{
-			public:
-				// members
-				Variable      initialValue;  // 00
-				TypeInfo      varType;       // 10
-				BSFixedString docString;     // 18
-				std::uint32_t userFlags;     // 20
-				bool          isConst;       // 24
-			};
-			static_assert(sizeof(StructVar) == 0x28);
-
-			const char* GetName() const
-			{
-				return name.c_str();
-			}
-
-			// override (IComplexType)
-			virtual TypeInfo::RawType GetRawType() const override { return TypeInfo::RawType::kStruct; }  // 01
-
 			// members
-			BSFixedString                                     name;                   // 10
-			BSTSmartPointer<ObjectTypeInfo>                   containingObjTypeInfo;  // 18
-			BSTArray<StructVar>                               variables;              // 20
-			/*BSTHashMap<BSFixedString, std::uint32_t>*/ char varNameIndexMap[0x38];  // 30
-			stl::enumeration<LinkValidState, std::int32_t>    linkedValid;            // 68
+			Variable      initialValue;  // 00
+			TypeInfo      varType;       // 10
+			BSFixedString docString;     // 18
+			std::uint32_t userFlags;     // 20
+			bool          isConst;       // 24
 		};
-		static_assert(sizeof(StructTypeInfo) == 0x70);
-	}
+		static_assert(sizeof(StructVar) == 0x28);
+
+		const char* GetName() const
+		{
+			return name.c_str();
+		}
+
+		// override (IComplexType)
+		virtual TypeInfo::RawType GetRawType() const override { return TypeInfo::RawType::kStruct; }  // 01
+
+		// members
+		BSFixedString                                     name;                   // 10
+		BSTSmartPointer<ObjectTypeInfo>                   containingObjTypeInfo;  // 18
+		BSTArray<StructVar>                               variables;              // 20
+		/*BSTHashMap<BSFixedString, std::uint32_t>*/ char varNameIndexMap[0x38];  // 30
+		stl::enumeration<LinkValidState, std::int32_t>    linkedValid;            // 68
+	};
+	static_assert(sizeof(StructTypeInfo) == 0x70);
 }

--- a/CommonLibSF/include/RE/T/TESForm.h
+++ b/CommonLibSF/include/RE/T/TESForm.h
@@ -12,12 +12,9 @@ namespace RE
 	class BGSSnapTemplateComponent;
 	class TESObjectREFR;
 
-	namespace BGSMod
+	namespace BGSMod::Template
 	{
-		namespace Template
-		{
-			class Items;
-		}
+		class Items;
 	}
 
 	struct FORM;

--- a/CommonLibSF/include/RE/T/TESObjectCELL.h
+++ b/CommonLibSF/include/RE/T/TESObjectCELL.h
@@ -108,7 +108,7 @@ namespace RE
 				kExteriorShort = 1 << 28,
 				kExteriorChar = 1 << 29,
 				kDetachTime = 1 << 30,
-				kSeenData = (std::uint32_t)1 << 31
+				kSeenData = static_cast<std::uint32_t>(1) << 31
 			};
 		};
 

--- a/CommonLibSF/include/RE/T/TypeInfo.h
+++ b/CommonLibSF/include/RE/T/TypeInfo.h
@@ -1,148 +1,145 @@
 #pragma once
 
-namespace RE
+namespace RE::BSScript
 {
-	namespace BSScript
+	class IComplexType;
+	class ObjectTypeInfo;
+	class StructTypeInfo;
+
+	class TypeInfo
 	{
-		class IComplexType;
-		class ObjectTypeInfo;
-		class StructTypeInfo;
-
-		class TypeInfo
+	public:
+		enum class RawType : std::uint32_t
 		{
-		public:
-			enum class RawType : std::uint32_t
-			{
-				kNone,
-				kObject,
-				kString,
-				kInt,
-				kFloat,
-				kBool,
-				kVar,
-				kStruct,
+			kNone,
+			kObject,
+			kString,
+			kInt,
+			kFloat,
+			kBool,
+			kVar,
+			kStruct,
 
-				kArrayStart = 10,
-				kArrayObject,
-				kArrayString,
-				kArrayInt,
-				kArrayFloat,
-				kArrayBool,
-				kArrayVar,
-				kArrayStruct,
-				kArrayEnd
-			};
-
-			TypeInfo() noexcept = default;
-			TypeInfo(const TypeInfo& a_rhs) noexcept { data.complexTypeInfo = a_rhs.data.complexTypeInfo; }
-			TypeInfo(TypeInfo&& a_rhs) noexcept { data.complexTypeInfo = std::exchange(a_rhs.data.complexTypeInfo, nullptr); }
-			TypeInfo(RawType a_type) noexcept { data.rawType = a_type; }
-			TypeInfo(IComplexType* a_type) noexcept { data.complexTypeInfo = a_type; }
-
-			TypeInfo& operator=(const TypeInfo& a_rhs) noexcept
-			{
-				if (this != std::addressof(a_rhs)) {
-					data.complexTypeInfo = a_rhs.data.complexTypeInfo;
-				}
-				return *this;
-			}
-
-			TypeInfo& operator=(TypeInfo&& a_rhs) noexcept
-			{
-				if (this != std::addressof(a_rhs)) {
-					data.complexTypeInfo = std::exchange(a_rhs.data.complexTypeInfo, nullptr);
-				}
-				return *this;
-			}
-
-			TypeInfo& operator=(RawType a_type) noexcept
-			{
-				data.rawType = a_type;
-				return *this;
-			}
-
-			TypeInfo& operator=(IComplexType* a_type) noexcept
-			{
-				data.complexTypeInfo = a_type;
-				return *this;
-			}
-
-			[[nodiscard]] RawType GetRawType() const;
-
-			[[nodiscard]] bool IsArray() const noexcept
-			{
-				if (IsComplex()) {
-					return data.rawType.all(static_cast<RawType>(1u));
-				} else {
-					return RawType::kArrayStart < data.rawType && data.rawType < RawType::kArrayEnd;
-				}
-			}
-
-			[[nodiscard]] bool IsComplex() const noexcept { return data.rawType >= RawType::kArrayEnd; }
-
-			[[nodiscard]] bool IsObjectArray() const noexcept
-			{
-				return GetRawType() == RawType::kArrayObject;
-			}
-			[[nodiscard]] bool IsStructArray() const noexcept
-			{
-				return GetRawType() == RawType::kArrayStruct;
-			}
-			[[nodiscard]] bool IsComplexTypeArray() const noexcept
-			{
-				return (IsComplex() && IsArray());
-			}
-			[[nodiscard]] bool IsObject() const { return GetRawType() == RawType::kObject; }
-			[[nodiscard]] bool IsStruct() const { return GetRawType() == RawType::kStruct; }
-			IComplexType*      GetComplexType() const
-			{
-				return IsComplex() ? reinterpret_cast<IComplexType*>(
-										 reinterpret_cast<std::uintptr_t>(data.complexTypeInfo) &
-										 ~static_cast<std::uintptr_t>(1)) :
-				                     nullptr;
-			}
-			ObjectTypeInfo* GetObjectTypeInfo() const
-			{
-				return IsObject() || IsObjectArray() ? reinterpret_cast<ObjectTypeInfo*>(GetComplexType()) : nullptr;
-			}
-			StructTypeInfo* GetStructTypeInfo() const
-			{
-				return IsStruct() || IsStructArray() ? reinterpret_cast<StructTypeInfo*>(GetComplexType()) : nullptr;
-			}
-			void SetArray(bool a_set) noexcept
-			{
-				if (IsComplex()) {
-					if (a_set) {
-						assert(!IsArray());
-						data.rawType.set(static_cast<RawType>(1u));
-					} else {
-						assert(IsArray());
-						data.rawType.reset(static_cast<RawType>(1u));
-					}
-				} else {
-					if (a_set) {
-						assert(!IsArray());
-						data.rawType += RawType::kArrayStart;
-					} else {
-						assert(IsArray());
-						data.rawType -= RawType::kArrayEnd;
-					}
-				}
-			}
-
-			// members
-			union D
-			{
-				D() noexcept :
-					complexTypeInfo(nullptr)
-				{}
-
-				~D() noexcept { complexTypeInfo = nullptr; }
-
-				stl::enumeration<RawType, std::uintptr_t> rawType;
-				IComplexType*                             complexTypeInfo;
-			} data;  // 0
+			kArrayStart = 10,
+			kArrayObject,
+			kArrayString,
+			kArrayInt,
+			kArrayFloat,
+			kArrayBool,
+			kArrayVar,
+			kArrayStruct,
+			kArrayEnd
 		};
-		static_assert(sizeof(TypeInfo) == 0x8);
-	}
+
+		TypeInfo() noexcept = default;
+		TypeInfo(const TypeInfo& a_rhs) noexcept { data.complexTypeInfo = a_rhs.data.complexTypeInfo; }
+		TypeInfo(TypeInfo&& a_rhs) noexcept { data.complexTypeInfo = std::exchange(a_rhs.data.complexTypeInfo, nullptr); }
+		TypeInfo(RawType a_type) noexcept { data.rawType = a_type; }
+		TypeInfo(IComplexType* a_type) noexcept { data.complexTypeInfo = a_type; }
+
+		TypeInfo& operator=(const TypeInfo& a_rhs) noexcept
+		{
+			if (this != std::addressof(a_rhs)) {
+				data.complexTypeInfo = a_rhs.data.complexTypeInfo;
+			}
+			return *this;
+		}
+
+		TypeInfo& operator=(TypeInfo&& a_rhs) noexcept
+		{
+			if (this != std::addressof(a_rhs)) {
+				data.complexTypeInfo = std::exchange(a_rhs.data.complexTypeInfo, nullptr);
+			}
+			return *this;
+		}
+
+		TypeInfo& operator=(RawType a_type) noexcept
+		{
+			data.rawType = a_type;
+			return *this;
+		}
+
+		TypeInfo& operator=(IComplexType* a_type) noexcept
+		{
+			data.complexTypeInfo = a_type;
+			return *this;
+		}
+
+		[[nodiscard]] RawType GetRawType() const;
+
+		[[nodiscard]] bool IsArray() const noexcept
+		{
+			if (IsComplex()) {
+				return data.rawType.all(static_cast<RawType>(1u));
+			} else {
+				return RawType::kArrayStart < data.rawType && data.rawType < RawType::kArrayEnd;
+			}
+		}
+
+		[[nodiscard]] bool IsComplex() const noexcept { return data.rawType >= RawType::kArrayEnd; }
+
+		[[nodiscard]] bool IsObjectArray() const noexcept
+		{
+			return GetRawType() == RawType::kArrayObject;
+		}
+		[[nodiscard]] bool IsStructArray() const noexcept
+		{
+			return GetRawType() == RawType::kArrayStruct;
+		}
+		[[nodiscard]] bool IsComplexTypeArray() const noexcept
+		{
+			return (IsComplex() && IsArray());
+		}
+		[[nodiscard]] bool IsObject() const { return GetRawType() == RawType::kObject; }
+		[[nodiscard]] bool IsStruct() const { return GetRawType() == RawType::kStruct; }
+		IComplexType*      GetComplexType() const
+		{
+			return IsComplex() ? reinterpret_cast<IComplexType*>(
+									 reinterpret_cast<std::uintptr_t>(data.complexTypeInfo) &
+									 ~static_cast<std::uintptr_t>(1)) :
+			                     nullptr;
+		}
+		ObjectTypeInfo* GetObjectTypeInfo() const
+		{
+			return IsObject() || IsObjectArray() ? reinterpret_cast<ObjectTypeInfo*>(GetComplexType()) : nullptr;
+		}
+		StructTypeInfo* GetStructTypeInfo() const
+		{
+			return IsStruct() || IsStructArray() ? reinterpret_cast<StructTypeInfo*>(GetComplexType()) : nullptr;
+		}
+		void SetArray(bool a_set) noexcept
+		{
+			if (IsComplex()) {
+				if (a_set) {
+					assert(!IsArray());
+					data.rawType.set(static_cast<RawType>(1u));
+				} else {
+					assert(IsArray());
+					data.rawType.reset(static_cast<RawType>(1u));
+				}
+			} else {
+				if (a_set) {
+					assert(!IsArray());
+					data.rawType += RawType::kArrayStart;
+				} else {
+					assert(IsArray());
+					data.rawType -= RawType::kArrayEnd;
+				}
+			}
+		}
+
+		// members
+		union D
+		{
+			D() noexcept :
+				complexTypeInfo(nullptr)
+			{}
+
+			~D() noexcept { complexTypeInfo = nullptr; }
+
+			stl::enumeration<RawType, std::uintptr_t> rawType;
+			IComplexType*                             complexTypeInfo;
+		} data;  // 0
+	};
+	static_assert(sizeof(TypeInfo) == 0x8);
 }

--- a/CommonLibSF/include/RE/V/Variable.h
+++ b/CommonLibSF/include/RE/V/Variable.h
@@ -5,319 +5,316 @@
 #include "RE/M/MemoryManager.h"
 #include "RE/T/TypeInfo.h"
 
-namespace RE
+namespace RE::BSScript
 {
-	namespace BSScript
+	class Array;
+	class Object;
+	class Struct;
+	class TypeInfo;
+	class Variable;
+
+	namespace detail
 	{
-		class Array;
-		class Object;
-		class Struct;
-		class TypeInfo;
-		class Variable;
+		struct variable_raw_accessor;
+	}
 
-		namespace detail
+	namespace UnlinkedTypes
+	{
+		struct Object;  // stub
+	}
+
+	class Variable
+	{
+	public:
+		Variable() noexcept = default;
+		Variable(const Variable& a_rhs) { copy(a_rhs); }
+		Variable(Variable&&) noexcept = default;
+
+		~Variable() { reset(); }
+
+		Variable& operator=(const Variable& a_rhs)
 		{
-			struct variable_raw_accessor;
+			if (this != std::addressof(a_rhs)) {
+				reset();
+				copy(a_rhs);
+			}
+			return *this;
 		}
 
-		namespace UnlinkedTypes
+		Variable& operator=(Variable&&) noexcept = default;
+
+		Variable& operator=(std::nullptr_t)
 		{
-			struct Object;  // stub
+			reset();
+			assert(is<std::nullptr_t>());
+			return *this;
 		}
 
-		class Variable
+		Variable& operator=(BSTSmartPointer<Object> a_object);
+
+		Variable& operator=(BSFixedString a_string)
 		{
-		public:
-			Variable() noexcept = default;
-			Variable(const Variable& a_rhs) { copy(a_rhs); }
-			Variable(Variable&&) noexcept = default;
+			reset();
+			value.s = std::move(a_string);
+			varType = RawType::kString;
 
-			~Variable() { reset(); }
+			assert(is<BSFixedString>());
+			return *this;
+		}
 
-			Variable& operator=(const Variable& a_rhs)
-			{
-				if (this != std::addressof(a_rhs)) {
-					reset();
-					copy(a_rhs);
-				}
-				return *this;
-			}
-
-			Variable& operator=(Variable&&) noexcept = default;
-
-			Variable& operator=(std::nullptr_t)
-			{
-				reset();
-				assert(is<std::nullptr_t>());
-				return *this;
-			}
-
-			Variable& operator=(BSTSmartPointer<Object> a_object);
-
-			Variable& operator=(BSFixedString a_string)
-			{
-				reset();
-				value.s = std::move(a_string);
-				varType = RawType::kString;
-
-				assert(is<BSFixedString>());
-				return *this;
-			}
-
-			Variable& operator=(std::uint32_t a_unsigned)
-			{
-				reset();
-				value.u = a_unsigned;
-				varType = RawType::kInt;
-
-				assert(is<std::uint32_t>());
-				return *this;
-			}
-
-			Variable& operator=(std::int32_t a_signed)
-			{
-				reset();
-				value.i = a_signed;
-				varType = RawType::kInt;
-
-				assert(is<std::int32_t>());
-				return *this;
-			}
-
-			Variable& operator=(float a_float)
-			{
-				reset();
-				value.f = a_float;
-				varType = RawType::kFloat;
-
-				assert(is<float>());
-				return *this;
-			}
-
-			Variable& operator=(bool a_boolean)
-			{
-				reset();
-				value.b = a_boolean;
-				varType = RawType::kBool;
-
-				assert(is<bool>());
-				return *this;
-			}
-
-			Variable& operator=(stl::owner<Variable*> a_variable)
-			{
-				assert(a_variable != nullptr);
-				assert(a_variable->varType.GetRawType() != RawType::kVar);
-
-				reset();
-				value.v = a_variable;
-				varType = RawType::kVar;
-				return *this;
-			}
-
-			Variable& operator=(BSTSmartPointer<Struct> a_struct);
-			Variable& operator=(BSTSmartPointer<Array> a_array);
-
-			SF_HEAP_REDEFINE_NEW(Variable);
-
-			template <class T>
-			[[nodiscard]] bool is() const  //
-				requires(std::same_as<T, std::nullptr_t>)
-			{
-				return varType.GetRawType() == RawType::kNone;
-			}
-
-			template <class T>
-			[[nodiscard]] bool is() const  //
-				requires(std::same_as<T, Object>)
-			{
-				return varType.GetRawType() == RawType::kObject;
-			}
-
-			template <class T>
-			[[nodiscard]] bool is() const  //
-				requires(std::same_as<T, BSFixedString>)
-			{
-				return varType.GetRawType() == RawType::kString;
-			}
-
-			template <class T>
-			[[nodiscard]] bool is() const  //
-				requires(std::same_as<T, std::uint32_t> ||
-						 std::same_as<T, std::int32_t>)
-			{
-				return varType.GetRawType() == RawType::kInt;
-			}
-
-			template <class T>
-			[[nodiscard]] bool is() const  //
-				requires(std::same_as<T, float>)
-			{
-				return varType.GetRawType() == RawType::kFloat;
-			}
-
-			template <class T>
-			[[nodiscard]] bool is() const  //
-				requires(std::same_as<T, bool>)
-			{
-				return varType.GetRawType() == RawType::kBool;
-			}
-
-			template <class T>
-			[[nodiscard]] bool is() const  //
-				requires(std::same_as<T, Variable>)
-			{
-				return varType.GetRawType() == RawType::kVar;
-			}
-
-			template <class T>
-			[[nodiscard]] bool is() const  //
-				requires(std::same_as<T, Struct>)
-			{
-				return varType.GetRawType() == RawType::kStruct;
-			}
-
-			template <class T>
-			[[nodiscard]] bool is() const  //
-				requires(std::same_as<T, Array>)
-			{
-				return varType.IsArray();
-			}
-
-			TypeInfo GetType() const
-			{
-				return varType;
-			}
-
-			void reset();
-
-		private:
-			friend detail::variable_raw_accessor;
-
-			using RawType = TypeInfo::RawType;
-
-			void copy(const Variable& a_rhs);
-
-			// members
-			TypeInfo varType;  // 00
-			union V
-			{
-				// NOLINTNEXTLINE(modernize-use-equals-default)
-				V() :
-					v(nullptr)
-				{}
-
-				V(V&& a_rhs) noexcept :
-					v(std::exchange(a_rhs.v, nullptr))
-				{}
-
-				~V() {}  // NOLINT(modernize-use-equals-default)
-
-				V& operator=(V&& a_rhs) noexcept
-				{
-					if (this != std::addressof(a_rhs)) {
-						v = std::exchange(a_rhs.v, nullptr);
-					}
-					return *this;
-				}
-
-				BSTSmartPointer<Object> o;
-				BSFixedString           s;
-				std::uint32_t           u;
-				std::int32_t            i;
-				float                   f;
-				bool                    b;
-				stl::owner<Variable*>   v;
-				BSTSmartPointer<Struct> t;
-				BSTSmartPointer<Array>  a;
-			} value;  // 08
-		};
-		static_assert(sizeof(Variable) == 0x10);
-
-		namespace detail
+		Variable& operator=(std::uint32_t a_unsigned)
 		{
-			struct variable_raw_accessor
-			{
-			public:
-				template <class T>
-				[[nodiscard]] static auto&& get_raw(T&& a_var)  //
-					requires(std::same_as<std::remove_cvref_t<T>, Variable>)
-				{
-					return std::forward<T>(a_var).value;
-				}
-			};
+			reset();
+			value.u = a_unsigned;
+			varType = RawType::kInt;
+
+			assert(is<std::uint32_t>());
+			return *this;
+		}
+
+		Variable& operator=(std::int32_t a_signed)
+		{
+			reset();
+			value.i = a_signed;
+			varType = RawType::kInt;
+
+			assert(is<std::int32_t>());
+			return *this;
+		}
+
+		Variable& operator=(float a_float)
+		{
+			reset();
+			value.f = a_float;
+			varType = RawType::kFloat;
+
+			assert(is<float>());
+			return *this;
+		}
+
+		Variable& operator=(bool a_boolean)
+		{
+			reset();
+			value.b = a_boolean;
+			varType = RawType::kBool;
+
+			assert(is<bool>());
+			return *this;
+		}
+
+		Variable& operator=(stl::owner<Variable*> a_variable)
+		{
+			assert(a_variable != nullptr);
+			assert(a_variable->varType.GetRawType() != RawType::kVar);
+
+			reset();
+			value.v = a_variable;
+			varType = RawType::kVar;
+			return *this;
+		}
+
+		Variable& operator=(BSTSmartPointer<Struct> a_struct);
+		Variable& operator=(BSTSmartPointer<Array> a_array);
+
+		SF_HEAP_REDEFINE_NEW(Variable);
+
+		template <class T>
+		[[nodiscard]] bool is() const  //
+			requires(std::same_as<T, std::nullptr_t>)
+		{
+			return varType.GetRawType() == RawType::kNone;
 		}
 
 		template <class T>
-		[[nodiscard]] BSTSmartPointer<Object> get(const Variable& a_var)  //
+		[[nodiscard]] bool is() const  //
 			requires(std::same_as<T, Object>)
 		{
-			assert(a_var.is<Object>());
-			return detail::variable_raw_accessor::get_raw(a_var).o;
+			return varType.GetRawType() == RawType::kObject;
 		}
 
 		template <class T>
-		[[nodiscard]] BSFixedString get(const Variable& a_var)  //
+		[[nodiscard]] bool is() const  //
 			requires(std::same_as<T, BSFixedString>)
 		{
-			assert(a_var.is<BSFixedString>());
-			return detail::variable_raw_accessor::get_raw(a_var).s;
+			return varType.GetRawType() == RawType::kString;
 		}
 
 		template <class T>
-		[[nodiscard]] std::uint32_t get(const Variable& a_var)  //
-			requires(std::same_as<T, std::uint32_t>)
+		[[nodiscard]] bool is() const  //
+			requires(std::same_as<T, std::uint32_t> ||
+					 std::same_as<T, std::int32_t>)
 		{
-			assert(a_var.is<std::uint32_t>());
-			return detail::variable_raw_accessor::get_raw(a_var).u;
+			return varType.GetRawType() == RawType::kInt;
 		}
 
 		template <class T>
-		[[nodiscard]] std::int32_t get(const Variable& a_var)  //
-			requires(std::same_as<T, std::int32_t>)
-		{
-			assert(a_var.is<std::int32_t>());
-			return detail::variable_raw_accessor::get_raw(a_var).i;
-		}
-
-		template <class T>
-		[[nodiscard]] float get(const Variable& a_var)  //
+		[[nodiscard]] bool is() const  //
 			requires(std::same_as<T, float>)
 		{
-			assert(a_var.is<float>());
-			return detail::variable_raw_accessor::get_raw(a_var).f;
+			return varType.GetRawType() == RawType::kFloat;
 		}
 
 		template <class T>
-		[[nodiscard]] bool get(const Variable& a_var)  //
+		[[nodiscard]] bool is() const  //
 			requires(std::same_as<T, bool>)
 		{
-			assert(a_var.is<bool>());
-			return detail::variable_raw_accessor::get_raw(a_var).b;
+			return varType.GetRawType() == RawType::kBool;
 		}
 
 		template <class T>
-		[[nodiscard]] stl::observer<Variable*> get(const Variable& a_var)  //
+		[[nodiscard]] bool is() const  //
 			requires(std::same_as<T, Variable>)
 		{
-			assert(a_var.is<Variable>());
-			return detail::variable_raw_accessor::get_raw(a_var).v;
+			return varType.GetRawType() == RawType::kVar;
 		}
 
 		template <class T>
-		[[nodiscard]] BSTSmartPointer<Struct> get(const Variable& a_var)  //
+		[[nodiscard]] bool is() const  //
 			requires(std::same_as<T, Struct>)
 		{
-			assert(a_var.is<Struct>());
-			return detail::variable_raw_accessor::get_raw(a_var).t;
+			return varType.GetRawType() == RawType::kStruct;
 		}
 
 		template <class T>
-		[[nodiscard]] BSTSmartPointer<Array> get(const Variable& a_var)  //
+		[[nodiscard]] bool is() const  //
 			requires(std::same_as<T, Array>)
 		{
-			assert(a_var.is<Array>());
-			return detail::variable_raw_accessor::get_raw(a_var).a;
+			return varType.IsArray();
 		}
+
+		TypeInfo GetType() const
+		{
+			return varType;
+		}
+
+		void reset();
+
+	private:
+		friend detail::variable_raw_accessor;
+
+		using RawType = TypeInfo::RawType;
+
+		void copy(const Variable& a_rhs);
+
+		// members
+		TypeInfo varType;  // 00
+		union V
+		{
+			// NOLINTNEXTLINE(modernize-use-equals-default)
+			V() :
+				v(nullptr)
+			{}
+
+			V(V&& a_rhs) noexcept :
+				v(std::exchange(a_rhs.v, nullptr))
+			{}
+
+			~V() {}  // NOLINT(modernize-use-equals-default)
+
+			V& operator=(V&& a_rhs) noexcept
+			{
+				if (this != std::addressof(a_rhs)) {
+					v = std::exchange(a_rhs.v, nullptr);
+				}
+				return *this;
+			}
+
+			BSTSmartPointer<Object> o;
+			BSFixedString           s;
+			std::uint32_t           u;
+			std::int32_t            i;
+			float                   f;
+			bool                    b;
+			stl::owner<Variable*>   v;
+			BSTSmartPointer<Struct> t;
+			BSTSmartPointer<Array>  a;
+		} value;  // 08
+	};
+	static_assert(sizeof(Variable) == 0x10);
+
+	namespace detail
+	{
+		struct variable_raw_accessor
+		{
+		public:
+			template <class T>
+			[[nodiscard]] static auto&& get_raw(T&& a_var)  
+				requires(std::same_as<std::remove_cvref_t<T>, Variable>)
+			{
+				return std::forward<T>(a_var).value;
+			}
+		};
+	}
+
+	template <class T>
+	[[nodiscard]] BSTSmartPointer<Object> get(const Variable& a_var)  
+		requires(std::same_as<T, Object>)
+	{
+		assert(a_var.is<Object>());
+		return detail::variable_raw_accessor::get_raw(a_var).o;
+	}
+
+	template <class T>
+	[[nodiscard]] BSFixedString get(const Variable& a_var)  
+		requires(std::same_as<T, BSFixedString>)
+	{
+		assert(a_var.is<BSFixedString>());
+		return detail::variable_raw_accessor::get_raw(a_var).s;
+	}
+
+	template <class T>
+	[[nodiscard]] std::uint32_t get(const Variable& a_var)  
+		requires(std::same_as<T, std::uint32_t>)
+	{
+		assert(a_var.is<std::uint32_t>());
+		return detail::variable_raw_accessor::get_raw(a_var).u;
+	}
+
+	template <class T>
+	[[nodiscard]] std::int32_t get(const Variable& a_var)  
+		requires(std::same_as<T, std::int32_t>)
+	{
+		assert(a_var.is<std::int32_t>());
+		return detail::variable_raw_accessor::get_raw(a_var).i;
+	}
+
+	template <class T>
+	[[nodiscard]] float get(const Variable& a_var) 
+		requires(std::same_as<T, float>)
+	{
+		assert(a_var.is<float>());
+		return detail::variable_raw_accessor::get_raw(a_var).f;
+	}
+
+	template <class T>
+	[[nodiscard]] bool get(const Variable& a_var)  
+		requires(std::same_as<T, bool>)
+	{
+		assert(a_var.is<bool>());
+		return detail::variable_raw_accessor::get_raw(a_var).b;
+	}
+
+	template <class T>
+	[[nodiscard]] stl::observer<Variable*> get(const Variable& a_var)  
+		requires(std::same_as<T, Variable>)
+	{
+		assert(a_var.is<Variable>());
+		return detail::variable_raw_accessor::get_raw(a_var).v;
+	}
+
+	template <class T>
+	[[nodiscard]] BSTSmartPointer<Struct> get(const Variable& a_var)  
+		requires(std::same_as<T, Struct>)
+	{
+		assert(a_var.is<Struct>());
+		return detail::variable_raw_accessor::get_raw(a_var).t;
+	}
+
+	template <class T>
+	[[nodiscard]] BSTSmartPointer<Array> get(const Variable& a_var)  
+		requires(std::same_as<T, Array>)
+	{
+		assert(a_var.is<Array>());
+		return detail::variable_raw_accessor::get_raw(a_var).a;
 	}
 }

--- a/CommonLibSF/src/RE/A/Array.cpp
+++ b/CommonLibSF/src/RE/A/Array.cpp
@@ -1,196 +1,193 @@
 #include "RE/A/Array.h"
 
-namespace RE
+namespace RE::BSScript
 {
-	namespace BSScript
+	Array::~Array()
 	{
-		Array::~Array()
-		{
-			dtor();
-		}
+		dtor();
+	}
 
-		Array::Array(const TypeInfo* type_info, std::uint32_t initial_size)
-		{
-			ctor(type_info, initial_size);
-		}
+	Array::Array(const TypeInfo* type_info, std::uint32_t initial_size)
+	{
+		ctor(type_info, initial_size);
+	}
 
-		Array* Array::ctor(const TypeInfo* type_info, std::uint32_t initial_size)
-		{
-			using func_t = decltype(&Array::ctor);
-			REL::Relocation<func_t> func{ ID::BSScript::Array::ctor };
-			return func(this, type_info, initial_size);
-		}
+	Array* Array::ctor(const TypeInfo* type_info, std::uint32_t initial_size)
+	{
+		using func_t = decltype(&Array::ctor);
+		REL::Relocation<func_t> func{ ID::BSScript::Array::ctor };
+		return func(this, type_info, initial_size);
+	}
 
-		void Array::dtor()
-		{
-			using func_t = decltype(&Array::dtor);
-			REL::Relocation<func_t> func{ ID::BSScript::Array::dtor };
-			return func(this);
-		}
+	void Array::dtor()
+	{
+		using func_t = decltype(&Array::dtor);
+		REL::Relocation<func_t> func{ ID::BSScript::Array::dtor };
+		return func(this);
+	}
 
-		[[nodiscard]] auto Array::operator[](size_type a_pos)
-			-> reference
-		{
-			assert(a_pos < size());
-			return *(elements.data() + static_cast<std::ptrdiff_t>(a_pos));  // TODO: add operator[] to BSTArray
-		}
+	[[nodiscard]] auto Array::operator[](size_type a_pos)
+		-> reference
+	{
+		assert(a_pos < size());
+		return *(elements.data() + static_cast<std::ptrdiff_t>(a_pos));  // TODO: add operator[] to BSTArray
+	}
 
-		[[nodiscard]] auto Array::operator[](size_type a_pos) const
-			-> const_reference
-		{
-			assert(a_pos < size());
-			return *(elements.data() + static_cast<std::ptrdiff_t>(a_pos));
-		}
+	[[nodiscard]] auto Array::operator[](size_type a_pos) const
+		-> const_reference
+	{
+		assert(a_pos < size());
+		return *(elements.data() + static_cast<std::ptrdiff_t>(a_pos));
+	}
 
-		[[nodiscard]] auto Array::front()
-			-> reference
-		{
-			return operator[](0);
-		}
+	[[nodiscard]] auto Array::front()
+		-> reference
+	{
+		return operator[](0);
+	}
 
-		[[nodiscard]] auto Array::front() const
-			-> const_reference
-		{
-			return operator[](0);
-		}
+	[[nodiscard]] auto Array::front() const
+		-> const_reference
+	{
+		return operator[](0);
+	}
 
-		[[nodiscard]] auto Array::back()
-			-> reference
-		{
-			return operator[](size() - 1);
-		}
+	[[nodiscard]] auto Array::back()
+		-> reference
+	{
+		return operator[](size() - 1);
+	}
 
-		[[nodiscard]] auto Array::back() const
-			-> const_reference
-		{
-			return operator[](size() - 1);
-		}
+	[[nodiscard]] auto Array::back() const
+		-> const_reference
+	{
+		return operator[](size() - 1);
+	}
 
-		[[nodiscard]] auto Array::data() noexcept
-			-> pointer
-		{
-			return size() > 0 ? elements.data() : nullptr;
-		}
+	[[nodiscard]] auto Array::data() noexcept
+		-> pointer
+	{
+		return size() > 0 ? elements.data() : nullptr;
+	}
 
-		[[nodiscard]] auto Array::data() const noexcept
-			-> const_pointer
-		{
-			return size() > 0 ? elements.data() : nullptr;
-		}
+	[[nodiscard]] auto Array::data() const noexcept
+		-> const_pointer
+	{
+		return size() > 0 ? elements.data() : nullptr;
+	}
 
-		[[nodiscard]] auto Array::begin() noexcept
-			-> iterator
-		{
-			return elements.begin();
-		}
+	[[nodiscard]] auto Array::begin() noexcept
+		-> iterator
+	{
+		return elements.begin();
+	}
 
-		[[nodiscard]] auto Array::begin() const noexcept
-			-> const_iterator
-		{
-			return elements.begin();
-		}
+	[[nodiscard]] auto Array::begin() const noexcept
+		-> const_iterator
+	{
+		return elements.begin();
+	}
 
-		[[nodiscard]] auto Array::cbegin() const noexcept
-			-> const_iterator
-		{
-			return elements.begin();
-		}
+	[[nodiscard]] auto Array::cbegin() const noexcept
+		-> const_iterator
+	{
+		return elements.begin();
+	}
 
-		[[nodiscard]] auto Array::end() noexcept
-			-> iterator
-		{
-			return size() > 0 ? elements.end() : nullptr;
-		}
+	[[nodiscard]] auto Array::end() noexcept
+		-> iterator
+	{
+		return size() > 0 ? elements.end() : nullptr;
+	}
 
-		[[nodiscard]] auto Array::end() const noexcept
-			-> const_iterator
-		{
-			return size() > 0 ? elements.end() : nullptr;
-		}
+	[[nodiscard]] auto Array::end() const noexcept
+		-> const_iterator
+	{
+		return size() > 0 ? elements.end() : nullptr;
+	}
 
-		[[nodiscard]] auto Array::cend() const noexcept
-			-> const_iterator
-		{
-			return elements.end();
-		}
+	[[nodiscard]] auto Array::cend() const noexcept
+		-> const_iterator
+	{
+		return elements.end();
+	}
 
-		[[nodiscard]] auto Array::rbegin() noexcept
-			-> reverse_iterator
-		{
-			return reverse_iterator(end());
-		}
+	[[nodiscard]] auto Array::rbegin() noexcept
+		-> reverse_iterator
+	{
+		return reverse_iterator(end());
+	}
 
-		[[nodiscard]] auto Array::rbegin() const noexcept
-			-> const_reverse_iterator
-		{
-			return const_reverse_iterator(end());
-		}
+	[[nodiscard]] auto Array::rbegin() const noexcept
+		-> const_reverse_iterator
+	{
+		return const_reverse_iterator(end());
+	}
 
-		[[nodiscard]] auto Array::crbegin() const noexcept
-			-> const_reverse_iterator
-		{
-			return rbegin();
-		}
+	[[nodiscard]] auto Array::crbegin() const noexcept
+		-> const_reverse_iterator
+	{
+		return rbegin();
+	}
 
-		[[nodiscard]] auto Array::rend() noexcept
-			-> reverse_iterator
-		{
-			return reverse_iterator(begin());
-		}
+	[[nodiscard]] auto Array::rend() noexcept
+		-> reverse_iterator
+	{
+		return reverse_iterator(begin());
+	}
 
-		[[nodiscard]] auto Array::rend() const noexcept
-			-> const_reverse_iterator
-		{
-			return const_reverse_iterator(begin());
-		}
+	[[nodiscard]] auto Array::rend() const noexcept
+		-> const_reverse_iterator
+	{
+		return const_reverse_iterator(begin());
+	}
 
-		[[nodiscard]] auto Array::crend() const noexcept
-			-> const_reverse_iterator
-		{
-			return rend();
-		}
+	[[nodiscard]] auto Array::crend() const noexcept
+		-> const_reverse_iterator
+	{
+		return rend();
+	}
 
-		[[nodiscard]] bool Array::empty() const noexcept
-		{
-			return size() > 0;
-		}
+	[[nodiscard]] bool Array::empty() const noexcept
+	{
+		return size() > 0;
+	}
 
-		[[nodiscard]] auto Array::size() const noexcept
-			-> size_type
-		{
-			return elements.size();
-		}
+	[[nodiscard]] auto Array::size() const noexcept
+		-> size_type
+	{
+		return elements.size();
+	}
 
-		[[nodiscard]] auto Array::max_size() const noexcept
-			-> size_type
-		{
-			return std::numeric_limits<size_type>::max();
-		}
+	[[nodiscard]] auto Array::max_size() const noexcept
+		-> size_type
+	{
+		return std::numeric_limits<size_type>::max();
+	}
 
-		[[nodiscard]] TypeInfo& Array::type_info()
-		{
-			return elementType;
-		}
+	[[nodiscard]] TypeInfo& Array::type_info()
+	{
+		return elementType;
+	}
 
-		[[nodiscard]] const TypeInfo& Array::type_info() const
-		{
-			return elementType;
-		}
+	[[nodiscard]] const TypeInfo& Array::type_info() const
+	{
+		return elementType;
+	}
 
-		[[nodiscard]] TypeInfo::RawType Array::type() const
-		{
-			const stl::enumeration typeID = elementType.GetRawType();
-			switch (*typeID) {
-			case TypeInfo::RawType::kNone:
-			case TypeInfo::RawType::kObject:
-			case TypeInfo::RawType::kString:
-			case TypeInfo::RawType::kInt:
-			case TypeInfo::RawType::kFloat:
-			case TypeInfo::RawType::kBool:
-				return *(typeID + TypeInfo::RawType::kArrayStart);
-			default:
-				return *(typeID + TypeInfo::RawType::kObject);
-			}
+	[[nodiscard]] TypeInfo::RawType Array::type() const
+	{
+		const stl::enumeration typeID = elementType.GetRawType();
+		switch (*typeID) {
+		case TypeInfo::RawType::kNone:
+		case TypeInfo::RawType::kObject:
+		case TypeInfo::RawType::kString:
+		case TypeInfo::RawType::kInt:
+		case TypeInfo::RawType::kFloat:
+		case TypeInfo::RawType::kBool:
+			return *(typeID + TypeInfo::RawType::kArrayStart);
+		default:
+			return *(typeID + TypeInfo::RawType::kObject);
 		}
 	}
 }

--- a/CommonLibSF/src/RE/B/BGSKeywordForm.cpp
+++ b/CommonLibSF/src/RE/B/BGSKeywordForm.cpp
@@ -5,7 +5,7 @@ namespace RE
 {
 	bool BGSKeywordForm::ContainsKeywordString(std::string_view a_editorID)
 	{
-		bool result = false;
+		bool result{};
 		ForEachKeyword([&](const BGSKeyword* a_keyword) {
 			if (result = a_keyword->formEditorID.contains(a_editorID); result) {
 				return BSContainer::ForEachResult::kStop;
@@ -36,7 +36,7 @@ namespace RE
 
 	bool BGSKeywordForm::HasKeywordString(std::string_view a_editorID)
 	{
-		bool result = false;
+		bool result{};
 		ForEachKeyword([&](const BGSKeyword* a_keyword) {
 			if (result = (a_keyword->formEditorID == a_editorID); result) {
 				return BSContainer::ForEachResult::kStop;

--- a/CommonLibSF/src/RE/S/Struct.cpp
+++ b/CommonLibSF/src/RE/S/Struct.cpp
@@ -1,4 +1,5 @@
 #include "RE/S/Struct.h"
+
 #include "RE/V/Variable.h"
 
 namespace RE::BSScript

--- a/CommonLibSF/src/RE/T/TESObjectCELL.cpp
+++ b/CommonLibSF/src/RE/T/TESObjectCELL.cpp
@@ -1,4 +1,5 @@
 #include "RE/T/TESObjectCELL.h"
+
 #include "RE/T/TESObjectREFR.h"
 
 namespace RE

--- a/CommonLibSF/src/RE/T/TESObjectREFR.cpp
+++ b/CommonLibSF/src/RE/T/TESObjectREFR.cpp
@@ -1,4 +1,5 @@
 #include "RE/T/TESObjectREFR.h"
+
 #include "RE/B/BGSInventoryItem.h"
 #include "RE/E/ExtraLock.h"
 

--- a/CommonLibSF/src/RE/T/TypeInfo.cpp
+++ b/CommonLibSF/src/RE/T/TypeInfo.cpp
@@ -1,6 +1,7 @@
-
 #include "RE/T/TypeInfo.h"
+
 #include "RE/I/IComplexType.h"
+
 namespace RE::BSScript
 {
 	auto TypeInfo::GetRawType() const
@@ -11,11 +12,11 @@ namespace RE::BSScript
 				reinterpret_cast<IComplexType*>(
 					reinterpret_cast<std::uintptr_t>(data.complexTypeInfo) &
 					~static_cast<std::uintptr_t>(1));
-			uint32_t rtype = (uint32_t)complex->GetRawType();
+			auto rtype = static_cast<uint32_t>(complex->GetRawType());
 			if (IsArray()) {
 				rtype += 10;
 			}
-			return (RawType)rtype;
+			return static_cast<RawType>(rtype);
 		} else {
 			return *data.rawType;
 		}

--- a/CommonLibSF/src/RE/V/Variable.cpp
+++ b/CommonLibSF/src/RE/V/Variable.cpp
@@ -1,4 +1,5 @@
 #include "RE/V/Variable.h"
+
 #include "RE/A/Array.h"
 #include "RE/O/Object.h"
 #include "RE/O/ObjectTypeInfo.h"


### PR DESCRIPTION
- Collapse some namespaces
- Remove unused includes
- Convert C-style casts to `static_cast`s 
- Normalize zero-/null-initialization of variables 