### PR TITLE
feat: add SFSE_BUILD_TESTS option

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -38,5 +38,6 @@ jobs:
           cmakeListsTxtPath: "${{ github.workspace }}/CommonLibSF/CMakeLists.txt"
           configurePreset: build-release-${{ matrix.compiler }}-ninja-vcpkg
           configurePresetCmdString: "[`-B`, `$[env.GITHUB_WORKSPACE]/build`, `-S`, `$[env.GITHUB_WORKSPACE]/CommonLibSF`, `--preset`, `$[env.CONFIGURE_PRESET_NAME]`]"
+          configurePresetAdditionalArgs: "['-DSFSE_BUILD_TESTS=true']"
           buildPreset: release-${{ matrix.compiler }}-ninja-vcpkg
           buildPresetCmdString: "[`--build`, `$[env.GITHUB_WORKSPACE]/build`, `--preset`, `$[env.BUILD_PRESET_NAME]`]"

--- a/CommonLibSF/CMakeLists.txt
+++ b/CommonLibSF/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 
 # options if not defined
 option(SFSE_SUPPORT_XBYAK "Enables trampoline support for Xbyak." OFF)
+option(SFSE_BUILD_TESTS "Builds the tests." OFF)
 
 # info
 project(
@@ -65,94 +66,111 @@ add_library(
 
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
-target_compile_definitions(
-  ${PROJECT_NAME}
-  PUBLIC
-    WINVER=0x0A00	# windows 10, minimum supported version by starfield
-    _WIN32_WINNT=0x0A00
-    "$<$<BOOL:${SFSE_SUPPORT_XBYAK}>:SFSE_SUPPORT_XBYAK=1>"
-)
-
-# FIXME: https://gitlab.kitware.com/cmake/cmake/-/issues/24922
-set_property(
-  TARGET ${PROJECT_NAME}
-  PROPERTY VS_USER_PROPS
-    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/build_stl_modules.props"
-)
-
-if(MSVC)
-  target_compile_options(
-    ${PROJECT_NAME}
+function (configure_target TARGET_NAME)
+  target_compile_definitions(
+    ${TARGET_NAME}
     PUBLIC
-      /bigobj # support large object file format
-      /utf-8  # assume UTF-8 sources even without a BOM
-
-    # warnings -> errors
-      /we4715	# 'function' : not all control paths return a value
-
-    # disable warnings
-      /wd4005 # macro redefinition
-      /wd4061 # enumerator 'identifier' in switch of enum 'enumeration' is not explicitly handled by a case label
-      /wd4068 # unknown pragma
-      /wd4200 # nonstandard extension used : zero-sized array in struct/union
-      /wd4201 # nonstandard extension used : nameless struct/union
-      /wd4265 # 'type': class has virtual functions, but its non-trivial destructor is not virtual; instances of this class may not be destructed correctly
-      /wd4266 # 'function' : no override available for virtual member function from base 'type'; function is hidden
-      /wd4267 # 'var' : conversion from 'size_t' to 'type', possible loss of data
-      /wd4371 # 'classname': layout of class may have changed from a previous version of the compiler due to better packing of member 'member'
-      /wd4514 # 'function' : unreferenced inline function has been removed
-      /wd4582 # 'type': constructor is not implicitly called
-      /wd4583 # 'type': destructor is not implicitly called
-      /wd4623 # 'derived class' : default constructor was implicitly defined as deleted because a base class default constructor is inaccessible or deleted
-      /wd4625 # 'derived class' : copy constructor was implicitly defined as deleted because a base class copy constructor is inaccessible or deleted
-      /wd4626 # 'derived class' : assignment operator was implicitly defined as deleted because a base class assignment operator is inaccessible or deleted
-      /wd4710 # 'function' : function not inlined
-      /wd4711 # function 'function' selected for inline expansion
-      /wd4820 # 'bytes' bytes padding added after construct 'member_name'
-      /wd4996
-      /wd5026 # 'type': move constructor was implicitly defined as deleted
-      /wd5027 # 'type': move assignment operator was implicitly defined as deleted
-      /wd5045 # Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
-      /wd5053 # support for 'explicit(<expr>)' in C++17 and earlier is a vendor extension
-      /wd5204 # 'type-name': class has virtual functions, but its trivial destructor is not virtual; instances of objects derived from this class may not be destructed correctly
-      /wd5220 # 'member': a non-static data member with a volatile qualified type no longer implies that compiler generated copy / move constructors and copy / move assignment operators are not trivial
+      WINVER=0x0A00	# windows 10, minimum supported version by starfield
+      _WIN32_WINNT=0x0A00
+      "$<$<BOOL:${SFSE_SUPPORT_XBYAK}>:SFSE_SUPPORT_XBYAK=1>"
   )
-endif()
 
-target_include_directories(
-  ${PROJECT_NAME}
-  PUBLIC
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
-)
+  # FIXME: https://gitlab.kitware.com/cmake/cmake/-/issues/24922
+  set_property(
+    TARGET ${TARGET_NAME}
+    PROPERTY VS_USER_PROPS
+      "${CMAKE_CURRENT_SOURCE_DIR}/cmake/build_stl_modules.props"
+  )
 
-target_link_libraries(
-  ${PROJECT_NAME}
-  PUBLIC
-    spdlog::spdlog
-    Version.lib
-    Dbghelp.lib
-)
+  if(MSVC)
+    target_compile_options(
+      ${TARGET_NAME}
+      PUBLIC
+        /bigobj # support large object file format
+        /utf-8  # assume UTF-8 sources even without a BOM
 
-if(SFSE_SUPPORT_XBYAK)
-  if(USING_VCPKG)
-    find_package(xbyak CONFIG REQUIRED)
-  else()
-    CPMAddPackage("gh:herumi/xbyak@6.73")
+      # warnings -> errors
+        /we4715	# 'function' : not all control paths return a value
+
+      # disable warnings
+        /wd4005 # macro redefinition
+        /wd4061 # enumerator 'identifier' in switch of enum 'enumeration' is not explicitly handled by a case label
+        /wd4068 # unknown pragma
+        /wd4200 # nonstandard extension used : zero-sized array in struct/union
+        /wd4201 # nonstandard extension used : nameless struct/union
+        /wd4265 # 'type': class has virtual functions, but its non-trivial destructor is not virtual; instances of this class may not be destructed correctly
+        /wd4266 # 'function' : no override available for virtual member function from base 'type'; function is hidden
+        /wd4267 # 'var' : conversion from 'size_t' to 'type', possible loss of data
+        /wd4371 # 'classname': layout of class may have changed from a previous version of the compiler due to better packing of member 'member'
+        /wd4514 # 'function' : unreferenced inline function has been removed
+        /wd4582 # 'type': constructor is not implicitly called
+        /wd4583 # 'type': destructor is not implicitly called
+        /wd4623 # 'derived class' : default constructor was implicitly defined as deleted because a base class default constructor is inaccessible or deleted
+        /wd4625 # 'derived class' : copy constructor was implicitly defined as deleted because a base class copy constructor is inaccessible or deleted
+        /wd4626 # 'derived class' : assignment operator was implicitly defined as deleted because a base class assignment operator is inaccessible or deleted
+        /wd4710 # 'function' : function not inlined
+        /wd4711 # function 'function' selected for inline expansion
+        /wd4820 # 'bytes' bytes padding added after construct 'member_name'
+        /wd4996
+        /wd5026 # 'type': move constructor was implicitly defined as deleted
+        /wd5027 # 'type': move assignment operator was implicitly defined as deleted
+        /wd5045 # Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
+        /wd5053 # support for 'explicit(<expr>)' in C++17 and earlier is a vendor extension
+        /wd5204 # 'type-name': class has virtual functions, but its trivial destructor is not virtual; instances of objects derived from this class may not be destructed correctly
+        /wd5220 # 'member': a non-static data member with a volatile qualified type no longer implies that compiler generated copy / move constructors and copy / move assignment operators are not trivial
+    )
   endif()
 
-  target_link_libraries(
-    ${PROJECT_NAME}
+  target_include_directories(
+    ${TARGET_NAME}
     PUBLIC
-      xbyak::xbyak
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+      "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
   )
+
+  target_link_libraries(
+    ${TARGET_NAME}
+    PUBLIC
+      spdlog::spdlog
+      Version.lib
+      Dbghelp.lib
+  )
+
+  if(SFSE_SUPPORT_XBYAK)
+    if(USING_VCPKG)
+      find_package(xbyak CONFIG REQUIRED)
+    else()
+      CPMAddPackage("gh:herumi/xbyak@6.73")
+    endif()
+  
+    target_link_libraries(
+      ${TARGET_NAME}
+      PUBLIC
+        xbyak::xbyak
+    )
+  endif()
+  
+  target_precompile_headers(
+    ${TARGET_NAME}
+    PRIVATE
+      include/SFSE/Impl/PCH.h
+  )
+endfunction()
+
+configure_target(${PROJECT_NAME})
+
+if (SFSE_BUILD_TESTS)
+  # add a custom library target that just builds test.cpp
+  add_library(
+    ${PROJECT_NAME}-test
+    STATIC
+      ${SOURCES}
+      .clang-format
+      ${CMAKE_CURRENT_SOURCE_DIR}/test/test.cpp
+  )
+  configure_target(${PROJECT_NAME}-test)
 endif()
 
-target_precompile_headers(
-  ${PROJECT_NAME}
-  PRIVATE
-    include/SFSE/Impl/PCH.h
-)
 
 if(USING_VCPKG)
   install(

--- a/CommonLibSF/cmake/make-sourcelist.ps1
+++ b/CommonLibSF/cmake/make-sourcelist.ps1
@@ -26,7 +26,7 @@ function Normalize-Path {
 
 function Resolve-Files {
     param (
-        [string[]]$range = @('include', 'src', 'test')
+        [string[]]$range = @('include', 'src')
     )
 
     process {

--- a/CommonLibSF/test/test.cpp
+++ b/CommonLibSF/test/test.cpp
@@ -1,0 +1,1 @@
+#include "RE/Starfield.h"


### PR DESCRIPTION
Just builds a cpp file that includes RE/Starfield.h so that we compile all the header files to check for errors, not just the ones that have modules