### PR TITLE
feat: add idTCP, idLogging

### DIFF
--- a/CommonLibSF/include/RE/I/idLogging.h
+++ b/CommonLibSF/include/RE/I/idLogging.h
@@ -1,0 +1,77 @@
+#pragma once
+
+namespace RE
+{
+	namespace idLogging
+	{
+		enum class Severity : std::uint8_t
+		{
+			Trace = 0,
+			Debug = 1,
+			Info = 2,
+			WARN = 3,
+			ERROR = 4,
+			FATAL = 5
+		};
+
+		struct ILogger
+		{
+			SF_RTTI_VTABLE(idLogging__ILogger);
+			~ILogger() = default;                                                                                 // 00
+			virtual bool ShouldLog(Severity severity) = 0;                                                        // 01
+			virtual void Log(const char* a_fileName, int a_line_number, Severity severity, const char* msg) = 0;  // 02
+			void Printf(const char* a_fileName, int a_line_number, Severity severity, const char* a_fmt, ...)
+			{
+				va_list args;
+				va_start(args, a_fmt);
+				char buffer[1064];
+				vsnprintf(buffer, 1024, a_fmt, args);
+				va_end(args);
+				Log(a_fileName, a_line_number, severity, buffer);
+			}
+		};
+
+		ILogger* GetLoggerSingleton();
+	}
+
+	// in an anonymous namespace in the exe
+	struct NetSocketLogger : public idLogging::ILogger
+	{
+		SF_RTTI_VTABLE(__NetSocketLogger);
+		~NetSocketLogger() = default;  // 00
+		// override idLogging::ILogger
+		bool ShouldLog([[maybe_unused]] idLogging::Severity severity) override { return false; }                     // 01
+		void Log(const char* a_fileName, int a_line_number, idLogging::Severity severity, const char* msg) override  // 02
+		{
+			const char* severitystr;
+			char        outputString[1032];
+			switch (severity)  // Trace, Debug, Info, WARN, ERROR, FATAL, UNKNOWN
+			{
+			case idLogging::Severity::Trace:
+				severitystr = "Trace";
+				break;
+			case idLogging::Severity::Debug:
+
+				severitystr = "Debug";
+				break;
+			case idLogging::Severity::Info:
+				severitystr = "Info";
+				break;
+			case idLogging::Severity::WARN:
+				severitystr = "WARN";
+				break;
+			case idLogging::Severity::ERROR:
+				severitystr = "ERROR";
+				break;
+			case idLogging::Severity::FATAL:
+				severitystr = "FATAL";
+				break;
+			default:
+				severitystr = "UNKNOWN";
+				break;
+			}
+			snprintf(outputString, 1024, "%s: %s - [%s (%d)]\n", severitystr, msg, a_fileName, a_line_number);
+			WinAPI::OutputDebugString(outputString);
+		}
+	};
+}

--- a/CommonLibSF/include/RE/I/idTCP.h
+++ b/CommonLibSF/include/RE/I/idTCP.h
@@ -1,0 +1,43 @@
+#pragma once
+
+namespace RE
+{
+	enum class netadrtype_t
+	{
+		NA_BAD,  // an address lookup failed
+		NA_LOOPBACK,
+		NA_BROADCAST,
+		NA_IP
+	};
+
+	struct netadr_t
+	{
+		netadrtype_t  type;   // 00
+		std::byte     ip[4];  // 04
+		std::uint32_t port;   // 08
+	};
+	static_assert(sizeof(netadr_t) == 0xC);
+
+	const char* NET_ErrorString(void);
+	void        Net_SockadrToNetadr(WinAPI::sockaddr* s, netadr_t* a);  // They violated the naming convention here :(
+	bool        NET_WaitForData(std::uintptr_t socket, std::uint32_t timeoutMs);
+	void        Sys_InitNetworking();
+
+	class idTCP
+	{
+		SF_RTTI_VTABLE(idTCP);
+
+		virtual ~idTCP();                                        // 00
+		bool         Listen(std::uint16_t port, bool blocking);  // 'blocking' is ignored
+		bool         Accept(const idTCP& listener);
+		std::int32_t Close();
+		std::int32_t Read(void* buffer, std::uint32_t size);
+		std::int32_t Write(const void* buffer, std::uint32_t size, std::uint32_t timeoutMs);
+
+		// members
+		netadr_t       address;  // 08
+		std::uintptr_t socket;   // 18
+	};
+	static_assert(sizeof(idTCP) == 0x20);
+
+}

--- a/CommonLibSF/include/RE/IDs.h
+++ b/CommonLibSF/include/RE/IDs.h
@@ -150,6 +150,20 @@ namespace RE::ID
 		inline constexpr REL::ID HasType{ 83208 };
 	}
 
+	namespace idLogging
+	{
+		inline constexpr REL::ID singleton{ 895197 };
+	}
+
+	namespace idTCP
+	{
+		inline constexpr REL::ID Accept{ 211257 };
+		inline constexpr REL::ID Close{ 211258 };
+		inline constexpr REL::ID Listen{ 211259 };
+		inline constexpr REL::ID Read{ 211264 };
+		inline constexpr REL::ID Write{ 211266 };
+	}
+
 	namespace LockPickedEvent
 	{
 		inline constexpr REL::ID GetEventSource{ 107115 };
@@ -309,4 +323,9 @@ namespace RE::ID
 
 	inline constexpr REL::ID RTDynamicCast{ 211916 };
 
+	// idCoreSocket functions
+	inline constexpr REL::ID NET_ErrorString{ 211261 };
+	inline constexpr REL::ID Net_SockadrToNetadr{ 211262 };
+	inline constexpr REL::ID NET_WaitForData{ 211263 };
+	inline constexpr REL::ID Sys_InitNetworking{ 211265 };
 }

--- a/CommonLibSF/include/RE/Starfield.h
+++ b/CommonLibSF/include/RE/Starfield.h
@@ -107,6 +107,8 @@
 #include "RE/I/IPostAnimationChannelUpdateFunctor.h"
 #include "RE/I/IStoreAnimationActions.h"
 #include "RE/I/IVMObjectBindInterface.h"
+#include "RE/I/idLogging.h"
+#include "RE/I/idTCP.h"
 #include "RE/IDs.h"
 #include "RE/IDs_NiRTTI.h"
 #include "RE/IDs_RTTI.h"

--- a/CommonLibSF/include/SFSE/Impl/WinAPI.h
+++ b/CommonLibSF/include/SFSE/Impl/WinAPI.h
@@ -181,7 +181,51 @@ namespace SFSE::WinAPI
 	inline constexpr auto UNDNAME_NAME_ONLY{ 0x00001000u };
 	inline constexpr auto UNDNAME_NO_ARGUMENTS{ 0x00002000u };
 
+	// winsock2 values
+	inline constexpr auto INADDR_ANY{ 0x00000000u };
+	inline constexpr auto INADDR_LOOPBACK{ 0x7f000001u };
+	inline constexpr auto INADDR_BROADCAST{ 0xffffffffu };
+	inline constexpr auto INADDR_NONE{ 0xffffffffu };
+
 	using THREAD_START_ROUTINE = std::uint32_t(void* a_param);
+
+	using UINT_PTR = std::uintptr_t;
+
+	enum class AFType : std::uint16_t
+	{
+		AF_UNSPEC = 0,
+		AF_UNIX = 1,
+		AF_INET = 2,
+		AF_IMPLINK = 3,
+		AF_PUP = 4,
+		AF_CHAOS = 5,
+		AF_NS = 6,
+		AF_IPX = AF_NS,
+		AF_ISO = 7,
+		AF_OSI = AF_ISO,
+		AF_ECMA = 8,
+		AF_DATAKIT = 9,
+		AF_CCITT = 10,
+		AF_SNA = 11,
+		AF_DECnet = 12,
+		AF_DLI = 13,
+		AF_LAT = 14,
+		AF_HYLINK = 15,
+		AF_APPLETALK = 16,
+		AF_NETBIOS = 17,
+		AF_VOICEVIEW = 18,
+		AF_FIREFOX = 19,
+		AF_UNKNOWN1 = 20,
+		AF_BAN = 21,
+		AF_ATM = 22,
+		AF_INET6 = 23,
+		AF_CLUSTER = 24,
+		AF_12844 = 25,
+		AF_IRDA = 26,
+		AF_NETDES = 28,
+	};
+
+	using ADDRESS_FAMILY = AFType;
 
 	struct CRITICAL_SECTION
 	{
@@ -419,6 +463,55 @@ namespace SFSE::WinAPI
 	};
 	static_assert(sizeof(SECURITY_ATTRIBUTES) == 0x18);
 
+	using SOCKET = UINT_PTR;
+
+	struct sockaddr
+	{
+		ADDRESS_FAMILY sa_family;
+		char           sa_data[14];
+	};
+
+	// Originally a struct with several #defines that served as aliases to members
+	// The defines screwed a lot of things up, so it was made a union.
+	// This means it won't have compatibility with code that uses in_addrs directly and
+	// also refers to it by its full type identifier (i.e. `struct in_addr`).
+	union in_addr
+	{
+		union in_addr_D
+		{
+			struct
+			{
+				std::uint8_t s_b1, s_b2, s_b3, s_b4;
+			} S_un_b;
+			struct
+			{
+				std::uint16_t s_w1, s_w2;
+			} S_un_w;
+			std::uint32_t S_addr;
+		} S_un;
+		// getting around the #DEFINEs in inaddr.h
+		struct
+		{
+			std::uint8_t s_net;
+			std::uint8_t s_host;
+			std::uint8_t s_lh;
+			std::uint8_t s_impno;
+		};
+		struct
+		{
+			std::uint16_t _s_w1, s_imp;
+		};
+		std::uint32_t s_addr;
+	};
+
+	struct sockaddr_in
+	{
+		ADDRESS_FAMILY sin_family;
+		std::uint16_t  sin_port;
+		in_addr        sin_addr;
+		char           sin_zero[8];
+	};
+
 	struct STARTUPINFOA
 	{
 		std::uint32_t size;
@@ -529,6 +622,102 @@ namespace SFSE::WinAPI
 		wchar_t       fileNameAlt[14];
 	};
 	static_assert(sizeof(WIN32_FIND_DATAW) == 0x250);
+
+	enum class WSAError : std::int32_t
+	{
+		WSABASEERR = 10000L,
+		WSAEINTR = 10004L,
+		WSAEBADF = 10009L,
+		WSAEACCES = 10013L,
+		WSAEFAULT = 10014L,
+		WSAEINVAL = 10022L,
+		WSAEMFILE = 10024L,
+		WSAEWOULDBLOCK = 10035L,
+		WSAEINPROGRESS = 10036L,
+		WSAEALREADY = 10037L,
+		WSAENOTSOCK = 10038L,
+		WSAEDESTADDRREQ = 10039L,
+		WSAEMSGSIZE = 10040L,
+		WSAEPROTOTYPE = 10041L,
+		WSAENOPROTOOPT = 10042L,
+		WSAEPROTONOSUPPORT = 10043L,
+		WSAESOCKTNOSUPPORT = 10044L,
+		WSAEOPNOTSUPP = 10045L,
+		WSAEPFNOSUPPORT = 10046L,
+		WSAEAFNOSUPPORT = 10047L,
+		WSAEADDRINUSE = 10048L,
+		WSAEADDRNOTAVAIL = 10049L,
+		WSAENETDOWN = 10050L,
+		WSAENETUNREACH = 10051L,
+		WSAENETRESET = 10052L,
+		WSAECONNABORTED = 10053L,
+		WSAECONNRESET = 10054L,
+		WSAENOBUFS = 10055L,
+		WSAEISCONN = 10056L,
+		WSAENOTCONN = 10057L,
+		WSAESHUTDOWN = 10058L,
+		WSAETOOMANYREFS = 10059L,
+		WSAETIMEDOUT = 10060L,
+		WSAECONNREFUSED = 10061L,
+		WSAELOOP = 10062L,
+		WSAENAMETOOLONG = 10063L,
+		WSAEHOSTDOWN = 10064L,
+		WSAEHOSTUNREACH = 10065L,
+		WSAENOTEMPTY = 10066L,
+		WSAEPROCLIM = 10067L,
+		WSAEUSERS = 10068L,
+		WSAEDQUOT = 10069L,
+		WSAESTALE = 10070L,
+		WSAEREMOTE = 10071L,
+		WSASYSNOTREADY = 10091L,
+		WSAVERNOTSUPPORTED = 10092L,
+		WSANOTINITIALISED = 10093L,
+		WSAEDISCON = 10101L,
+		WSAENOMORE = 10102L,
+		WSAECANCELLED = 10103L,
+		WSAEINVALIDPROCTABLE = 10104L,
+		WSAEINVALIDPROVIDER = 10105L,
+		WSAEPROVIDERFAILEDINIT = 10106L,
+		WSASYSCALLFAILURE = 10107L,
+		WSASERVICE_NOT_FOUND = 10108L,
+		WSATYPE_NOT_FOUND = 10109L,
+		WSA_E_NO_MORE = 10110L,
+		WSA_E_CANCELLED = 10111L,
+		WSAEREFUSED = 10112L,
+		WSAHOST_NOT_FOUND = 11001L,
+		WSATRY_AGAIN = 11002L,
+		WSANO_RECOVERY = 11003L,
+		WSANO_DATA = 11004L,
+		WSA_QOS_RECEIVERS = 11005L,
+		WSA_QOS_SENDERS = 11006L,
+		WSA_QOS_NO_SENDERS = 11007L,
+		WSA_QOS_NO_RECEIVERS = 11008L,
+		WSA_QOS_REQUEST_CONFIRMED = 11009L,
+		WSA_QOS_ADMISSION_FAILURE = 11010L,
+		WSA_QOS_POLICY_FAILURE = 11011L,
+		WSA_QOS_BAD_STYLE = 11012L,
+		WSA_QOS_BAD_OBJECT = 11013L,
+		WSA_QOS_TRAFFIC_CTRL_ERROR = 11014L,
+		WSA_QOS_GENERIC_ERROR = 11015L,
+		WSA_QOS_ESERVICETYPE = 11016L,
+		WSA_QOS_EFLOWSPEC = 11017L,
+		WSA_QOS_EPROVSPECBUF = 11018L,
+		WSA_QOS_EFILTERSTYLE = 11019L,
+		WSA_QOS_EFILTERTYPE = 11020L,
+		WSA_QOS_EFILTERCOUNT = 11021L,
+		WSA_QOS_EOBJLENGTH = 11022L,
+		WSA_QOS_EFLOWCOUNT = 11023L,
+		WSA_QOS_EUNKOWNPSOBJ = 11024L,
+		WSA_QOS_EPOLICYOBJ = 11025L,
+		WSA_QOS_EFLOWDESC = 11026L,
+		WSA_QOS_EPSFLOWSPEC = 11027L,
+		WSA_QOS_EPSFILTERSPEC = 11028L,
+		WSA_QOS_ESDMODEOBJ = 11029L,
+		WSA_QOS_ESHAPERATEOBJ = 11030L,
+		WSA_QOS_RESERVED_PETYPE = 11031L,
+		WSA_SECURE_HOST_NOT_FOUND = 11032L,
+		WSA_IPSEC_NAME_POLICY_ERROR = 11033L,
+	};
 
 	enum VKEnum : std::uint32_t
 	{
@@ -956,6 +1145,8 @@ namespace SFSE::WinAPI
 	void GetSystemInfo(
 		SYSTEM_INFO* a_info) noexcept;
 
+	[[nodiscard]] std::uint16_t htons(std::uint16_t hostshort) noexcept;
+
 	[[nodiscard]] bool IMAGE_SNAP_BY_ORDINAL64(
 		std::uint64_t a_ordinal) noexcept;
 
@@ -1022,6 +1213,8 @@ namespace SFSE::WinAPI
 		std::int32_t   a_srcLen,
 		wchar_t*       a_dest,
 		std::int32_t   a_destLen);
+
+	[[nodiscard]] std::uint32_t ntohl(std::uint32_t netlong) noexcept;
 
 	[[nodiscard]] void* OpenFileMapping(
 		std::uint32_t a_desiredAccess,
@@ -1184,6 +1377,8 @@ namespace SFSE::WinAPI
 		std::int32_t   a_strLen,
 		const char*    a_default,
 		std::int32_t*  a_defaultLen);
+
+	[[nodiscard]] std::int32_t WSAGetLastError() noexcept;
 
 	[[nodiscard]] bool WriteProcessMemory(
 		void*        a_process,

--- a/CommonLibSF/src/RE/I/idLogging.cpp
+++ b/CommonLibSF/src/RE/I/idLogging.cpp
@@ -1,0 +1,10 @@
+#include "RE/I/idLogging.h"
+
+namespace RE::idLogging
+{
+	ILogger* GetLoggerSingleton()
+	{
+		REL::Relocation<ILogger**> singleton{ ID::idLogging::singleton };
+		return *singleton;
+	}
+}

--- a/CommonLibSF/src/RE/I/idTCP.cpp
+++ b/CommonLibSF/src/RE/I/idTCP.cpp
@@ -1,0 +1,171 @@
+#include "RE/I/idTCP.h"
+
+namespace RE
+{
+	const char* NET_ErrorString(void)
+	{
+		using WSAError = WinAPI::WSAError;
+		WSAError code = static_cast<WSAError>(WinAPI::WSAGetLastError());
+		switch (code) {
+		case WSAError::WSAEINTR:
+			return "WSAEINTR";
+		case WSAError::WSAEBADF:
+			return "WSAEBADF";
+		case WSAError::WSAEACCES:
+			return "WSAEACCES";
+		case WSAError::WSAEDISCON:
+			return "WSAEDISCON";
+		case WSAError::WSAEFAULT:
+			return "WSAEFAULT";
+		case WSAError::WSAEINVAL:
+			return "WSAEINVAL";
+		case WSAError::WSAEMFILE:
+			return "WSAEMFILE";
+		case WSAError::WSAEWOULDBLOCK:
+			return "WSAEWOULDBLOCK";
+		case WSAError::WSAEINPROGRESS:
+			return "WSAEINPROGRESS";
+		case WSAError::WSAEALREADY:
+			return "WSAEALREADY";
+		case WSAError::WSAENOTSOCK:
+			return "WSAENOTSOCK";
+		case WSAError::WSAEDESTADDRREQ:
+			return "WSAEDESTADDRREQ";
+		case WSAError::WSAEMSGSIZE:
+			return "WSAEMSGSIZE";
+		case WSAError::WSAEPROTOTYPE:
+			return "WSAEPROTOTYPE";
+		case WSAError::WSAENOPROTOOPT:
+			return "WSAENOPROTOOPT";
+		case WSAError::WSAEPROTONOSUPPORT:
+			return "WSAEPROTONOSUPPORT";
+		case WSAError::WSAESOCKTNOSUPPORT:
+			return "WSAESOCKTNOSUPPORT";
+		case WSAError::WSAEOPNOTSUPP:
+			return "WSAEOPNOTSUPP";
+		case WSAError::WSAEPFNOSUPPORT:
+			return "WSAEPFNOSUPPORT";
+		case WSAError::WSAEAFNOSUPPORT:
+			return "WSAEAFNOSUPPORT";
+		case WSAError::WSAEADDRINUSE:
+			return "WSAEADDRINUSE";
+		case WSAError::WSAEADDRNOTAVAIL:
+			return "WSAEADDRNOTAVAIL";
+		case WSAError::WSAENETDOWN:
+			return "WSAENETDOWN";
+		case WSAError::WSAENETUNREACH:
+			return "WSAENETUNREACH";
+		case WSAError::WSAENETRESET:
+			return "WSAENETRESET";
+		case WSAError::WSAECONNABORTED:
+			return "WSWSAECONNABORTEDAEINTR";
+		case WSAError::WSAECONNRESET:
+			return "WSAECONNRESET";
+		case WSAError::WSAENOBUFS:
+			return "WSAENOBUFS";
+		case WSAError::WSAEISCONN:
+			return "WSAEISCONN";
+		case WSAError::WSAENOTCONN:
+			return "WSAENOTCONN";
+		case WSAError::WSAESHUTDOWN:
+			return "WSAESHUTDOWN";
+		case WSAError::WSAETOOMANYREFS:
+			return "WSAETOOMANYREFS";
+		case WSAError::WSAETIMEDOUT:
+			return "WSAETIMEDOUT";
+		case WSAError::WSAECONNREFUSED:
+			return "WSAECONNREFUSED";
+		case WSAError::WSAELOOP:
+			return "WSAELOOP";
+		case WSAError::WSAENAMETOOLONG:
+			return "WSAENAMETOOLONG";
+		case WSAError::WSAEHOSTDOWN:
+			return "WSAEHOSTDOWN";
+		case WSAError::WSASYSNOTREADY:
+			return "WSASYSNOTREADY";
+		case WSAError::WSAVERNOTSUPPORTED:
+			return "WSAVERNOTSUPPORTED";
+		case WSAError::WSANOTINITIALISED:
+			return "WSANOTINITIALISED";
+		case WSAError::WSAHOST_NOT_FOUND:
+			return "WSAHOST_NOT_FOUND";
+		case WSAError::WSATRY_AGAIN:
+			return "WSATRY_AGAIN";
+		case WSAError::WSANO_RECOVERY:
+			return "WSANO_RECOVERY";
+		case WSAError::WSANO_DATA:
+			return "WSANO_DATA";
+		default:
+			return "NO ERROR";
+		}
+	}
+
+	void Net_SockadrToNetadr(struct WinAPI::sockaddr* s, netadr_t* a)
+	{
+		using AFType = WinAPI::AFType;
+		using sockaddr_in = WinAPI::sockaddr_in;
+
+		unsigned int ip;
+		if (s->sa_family == AFType::AF_INET) {
+			sockaddr_in* sin = reinterpret_cast<sockaddr_in*>(s);
+			ip = sin->sin_addr.s_addr;
+			*(unsigned int*)&a->ip = ip;
+			a->port = WinAPI::htons(sin->sin_port);
+			ip = WinAPI::ntohl(ip);
+			if (ip == WinAPI::INADDR_LOOPBACK) {
+				a->type = netadrtype_t::NA_LOOPBACK;
+			} else {
+				a->type = netadrtype_t::NA_IP;
+			}
+		}
+	}
+
+	bool NET_WaitForData(std::uintptr_t socket, std::uint32_t timeoutMs)
+	{
+		using func_t = decltype(&NET_WaitForData);
+		REL::Relocation<func_t> func{ ID::NET_WaitForData };
+		return func(socket, timeoutMs);
+	}
+
+	void Sys_InitNetworking()
+	{
+		using func_t = decltype(&Sys_InitNetworking);
+		REL::Relocation<func_t> func{ ID::Sys_InitNetworking };
+		return func();
+	}
+	bool idTCP::Listen(std::uint16_t port, bool blocking)
+	{
+		using func_t = decltype(&idTCP::Listen);
+		REL::Relocation<func_t> func{ ID::idTCP::Listen };
+		return func(this, port, blocking);
+	}
+
+	bool idTCP::Accept(const idTCP& listener)
+	{
+		using func_t = decltype(&idTCP::Accept);
+		REL::Relocation<func_t> func{ ID::idTCP::Accept };
+		return func(this, listener);
+	}
+
+	std::int32_t idTCP::Close()
+	{
+		using func_t = decltype(&idTCP::Close);
+		REL::Relocation<func_t> func{ ID::idTCP::Close };
+		return func(this);
+	}
+
+	std::int32_t idTCP::Read(void* buffer, std::uint32_t size)
+	{
+		using func_t = decltype(&idTCP::Read);
+		REL::Relocation<func_t> func{ ID::idTCP::Read };
+		return func(this, buffer, size);
+	}
+
+	std::int32_t idTCP::Write(const void* buffer, std::uint32_t size, std::uint32_t timeoutMs)
+	{
+		using func_t = decltype(&idTCP::Write);
+		REL::Relocation<func_t> func{ ID::idTCP::Write };
+		return func(this, buffer, size, timeoutMs);
+	}
+
+}

--- a/CommonLibSF/src/SFSE/Impl/WinAPI.cpp
+++ b/CommonLibSF/src/SFSE/Impl/WinAPI.cpp
@@ -7,6 +7,7 @@
 #include <DbgHelp.h>
 #include <objbase.h>
 #include <ShlObj.h>
+#include <WinSock2.h>
 // clang-format on
 
 #undef CreateFileMapping
@@ -495,6 +496,11 @@ namespace SFSE::WinAPI
 			reinterpret_cast<LPSYSTEM_INFO>(a_info));
 	}
 
+	std::uint16_t htons(std::uint16_t hostshort) noexcept
+	{
+		return ::htons(hostshort);
+	}
+
 	bool IMAGE_SNAP_BY_ORDINAL64(
 		std::uint64_t a_ordinal) noexcept
 	{
@@ -642,6 +648,11 @@ namespace SFSE::WinAPI
 			a_srcLen,
 			a_dest,
 			a_destLen);
+	}
+
+	std::uint32_t ntohl(std::uint32_t netlong) noexcept
+	{
+		return ::ntohl(netlong);
 	}
 
 	void* OpenFileMapping(
@@ -1012,6 +1023,11 @@ namespace SFSE::WinAPI
 			a_strLen,
 			a_default,
 			a_defaultLen);
+	}
+
+	std::int32_t WSAGetLastError() noexcept
+	{
+		return ::WSAGetLastError();
 	}
 
 	bool WriteProcessMemory(


### PR DESCRIPTION
idTCP uses WinAPI types in its declarations; what is the policy on RE'd files using WinAPI types in their declarations?