### PR TITLE
feat: SFSE plugin version data update for 1.8.86 struct compat break

### DIFF
--- a/CommonLibSF/include/SFSE/Interfaces.h
+++ b/CommonLibSF/include/SFSE/Interfaces.h
@@ -187,11 +187,13 @@ namespace SFSE
 
 		constexpr void UsesSigScanning(const bool a_value) noexcept { SetOrClearBit(addressIndependence, 1 << 0, a_value); }
 
+		// 1 << 1 is for address library v1
 		constexpr void UsesAddressLibrary(const bool a_value) noexcept { SetOrClearBit(addressIndependence, 1 << 1, a_value); }
 
 		constexpr void HasNoStructUse(const bool a_value) noexcept { SetOrClearBit(structureCompatibility, 1 << 0, a_value); }
 
-		constexpr void IsLayoutDependent(const bool a_value) noexcept { SetOrClearBit(structureCompatibility, 1 << 1, a_value); }
+		// 1 << 2 is for runtime 1.8.86 and later
+		constexpr void IsLayoutDependent(const bool a_value) noexcept { SetOrClearBit(structureCompatibility, 1 << 2, a_value); }
 
 		constexpr void CompatibleVersions(std::initializer_list<REL::Version> a_versions) noexcept
 		{


### PR DESCRIPTION
This updates the SFSE version data to work with https://github.com/ianpatt/sfse/commit/59a5bba27701982e3522c88488ff3dd9fc61798b. Please do not merge until PR #229 is in.

Plugins releasing between taking this change and the next SFSE update (will either release something with busted class definitions just so plugins are OK, or fix that up and release depending on how long that takes) can call `CompatibleVersions({RUNTIME_SF_1_8_86})` on their version struct to explicitly specify compatibility with the current version of the game.