### PR TITLE
chore: bump latest SFSE version to 0.2.5

### DIFF
--- a/CommonLibSF/include/SFSE/Version.h
+++ b/CommonLibSF/include/SFSE/Version.h
@@ -9,7 +9,10 @@ namespace SFSE
 	constexpr REL::Version RUNTIME_SF_1_7_36(1, 7, 36, 0);
 	constexpr REL::Version RUNTIME_SF_1_8_86(1, 8, 86, 0);
 	constexpr REL::Version RUNTIME_SF_1_9_51(1, 9, 51, 0);
-	constexpr auto         RUNTIME_LATEST = RUNTIME_SF_1_9_51;
+	constexpr REL::Version RUNTIME_SF_1_9_67(1, 9, 67, 0);
+	constexpr REL::Version RUNTIME_SF_1_9_71(1, 9, 71, 0);
+	constexpr REL::Version RUNTIME_SF_1_10_31(1, 10, 31, 0);
+	constexpr auto         RUNTIME_LATEST = RUNTIME_SF_1_10_31;
 
-	constexpr REL::Version SFSE_PACK_LATEST(0, 2, 2, 0);
+	constexpr REL::Version SFSE_PACK_LATEST(0, 2, 5, 0);
 }


### PR DESCRIPTION
also add missing game versions
0.2.5 is estimated version number