### PR TITLE
feat: misc

### DIFF
--- a/include/RE/A/AVMData.h
+++ b/include/RE/A/AVMData.h
@@ -9,7 +9,7 @@ namespace RE
 	struct AVMData
 	{
 	public:
-		enum class TYPE
+		enum class Type : std::uint32_t
 		{
 			kNone,
 			kSimpleGroup,
@@ -28,9 +28,9 @@ namespace RE
 		};
 
 		// members
-		stl::enumeration<TYPE, std::uint32_t> type;      // 00
-		BSFixedString                         category;  // 08
-		Entry                                 unk10;     // 10
+		Type          type;      // 00
+		BSFixedString category;  // 08
+		Entry         unk10;     // 10
 	};
 	static_assert(sizeof(AVMData) == 0x28);
 }

--- a/include/RE/A/Actor.h
+++ b/include/RE/A/Actor.h
@@ -280,107 +280,107 @@ namespace RE
 		[[nodiscard]] bool IsHostileToActor(Actor* a_actor);
 
 		// members
-		stl::enumeration<BOOL_BITS, std::uint32_t>           boolBits;                 // 200
-		float                                                unk204;                   // 204
-		BSGuarded<BSTArray<void*>, BSSpinLock>               unk208;                   // 208 - BGSBody?
-		AIProcess*                                           currentProcess;           // 220
-		std::uint64_t                                        unk228;                   // 228
-		std::uint64_t                                        unk230;                   // 230
-		std::uint64_t                                        unk238;                   // 238
-		std::uint64_t                                        unk240;                   // 240
-		CombatController*                                    combatController;         // 248
-		std::uint64_t                                        unk250;                   // 250
-		ActorValueStorage                                    avStorage;                // 258
-		std::uint64_t                                        unk280;                   // 280
-		stl::enumeration<ACTOR_CRITICAL_STAGE, std::int32_t> criticalStage;            // 288
-		std::uint32_t                                        dialogueItemTarget;       // 28C - TESPointerHandle
-		std::uint32_t                                        currentCombatTarget;      // 290 - TESPointerHandle
-		std::uint32_t                                        myKiller;                 // 294 - TESPointerHandle
-		std::uint64_t                                        unk298;                   // 298
-		std::uint64_t                                        unk2A0;                   // 2A0
-		std::uint32_t                                        actionValue;              // 2A8
-		float                                                timerOnAction;            // 2AC
-		std::uint64_t                                        unk2B0;                   // 2B0
-		std::uint32_t                                        intimidateBribeDayStamp;  // 2B8
-		std::uint32_t                                        unk2BC;                   // 2BC
-		std::uint64_t                                        unk2C0;                   // 2C0
-		std::uint64_t                                        unk2C8;                   // 2C8
-		std::uint64_t                                        unk2D0;                   // 2D0
-		std::uint64_t                                        unk2D8;                   // 2D8
-		std::uint64_t                                        unk2E0;                   // 2E0
-		std::uint64_t                                        unk2E8;                   // 2E8
-		std::uint64_t                                        unk2F0;                   // 2F0
-		std::uint64_t                                        unk2F8;                   // 2F8
-		std::uint64_t                                        unk300;                   // 300
-		std::uint64_t                                        unk308;                   // 308
-		std::uint64_t                                        unk310;                   // 310
-		std::uint64_t                                        unk318;                   // 318
-		std::uint64_t                                        unk320;                   // 320
-		std::uint64_t                                        unk328;                   // 328
-		std::uint64_t                                        unk330;                   // 330
-		std::uint64_t                                        unk338;                   // 338
-		std::uint64_t                                        unk340;                   // 340
-		std::uint64_t                                        unk348;                   // 348
-		TESRace*                                             race;                     // 350
-		Perks*                                               perks;                    // 358
-		std::uint32_t                                        unk360;                   // 360
-		mutable BSReadWriteLock                              perkArrayLock;            // 364
-		std::uint32_t                                        unk35C;                   // 35C
-		stl::enumeration<BOOL_FLAGS, std::uint32_t>          boolFlags;                // 370
-		stl::enumeration<BOOL_FLAGS2, std::uint32_t>         boolFlags2;               // 374
-		std::uint64_t                                        unk378;                   // 378
-		std::uint64_t                                        unk380;                   // 380
-		std::uint64_t                                        unk388;                   // 388
-		std::uint64_t                                        unk390;                   // 390
-		std::uint64_t                                        unk398;                   // 398
-		std::uint64_t                                        unk3A0;                   // 3A0
-		std::uint64_t                                        unk3A8;                   // 3A8
-		std::uint64_t                                        unk3B0;                   // 3B0
-		std::uint64_t                                        unk3B8;                   // 3B8
-		std::uint64_t                                        unk3C0;                   // 3C0
-		std::uint64_t                                        unk3C8;                   // 3C8
-		std::uint64_t                                        unk3D0;                   // 3D0
-		std::uint64_t                                        unk3D8;                   // 3D8
-		std::uint64_t                                        unk3E0;                   // 3E0
-		std::uint64_t                                        unk3E8;                   // 3E8
-		std::uint64_t                                        unk3F0;                   // 3F0
-		std::uint64_t                                        unk3F8;                   // 3F8
-		std::uint64_t                                        unk400;                   // 400
-		std::uint64_t                                        unk408;                   // 408
-		std::uint64_t                                        unk410;                   // 410
-		std::uint64_t                                        unk418;                   // 418
-		std::uint64_t                                        unk420;                   // 420
-		std::uint64_t                                        unk428;                   // 428
-		std::uint64_t                                        unk430;                   // 430
-		std::uint64_t                                        unk438;                   // 438
-		std::uint64_t                                        unk440;                   // 440
-		std::uint64_t                                        unk448;                   // 448
-		std::uint64_t                                        unk450;                   // 450
-		std::uint64_t                                        unk458;                   // 458
-		std::uint64_t                                        unk460;                   // 460
-		std::uint64_t                                        unk468;                   // 468
-		std::uint64_t                                        unk470;                   // 470
-		std::uint64_t                                        unk478;                   // 478
-		std::uint64_t                                        unk480;                   // 480
-		std::uint64_t                                        unk488;                   // 488
-		std::uint64_t                                        unk490;                   // 490
-		std::uint64_t                                        unk498;                   // 498
-		std::uint64_t                                        unk4A0;                   // 4A0
-		std::uint64_t                                        unk4A8;                   // 4A8
-		std::uint64_t                                        unk4B0;                   // 4B0
-		std::uint64_t                                        unk4B8;                   // 4B8
-		std::uint64_t                                        unk4C0;                   // 4C0
-		std::uint64_t                                        unk4C8;                   // 4C8
-		std::uint64_t                                        unk4D0;                   // 4D0
-		std::uint64_t                                        unk4D8;                   // 4D8
-		std::uint64_t                                        unk4E0;                   // 4E0
-		std::uint64_t                                        unk4E8;                   // 4E8
-		std::uint64_t                                        unk4F0;                   // 4F0
-		std::uint64_t                                        unk4F8;                   // 4F8
-		std::uint64_t                                        unk500;                   // 500
-		std::uint64_t                                        unk508;                   // 508
-		std::uint64_t                                        unk510;                   // 510
-		std::uint8_t                                         unk518[88];               // 518
+		REX::EnumSet<BOOL_BITS, std::uint32_t>           boolBits;                 // 200
+		float                                            unk204;                   // 204
+		BSGuarded<BSTArray<void*>, BSSpinLock>           unk208;                   // 208 - BGSBody?
+		AIProcess*                                       currentProcess;           // 220
+		std::uint64_t                                    unk228;                   // 228
+		std::uint64_t                                    unk230;                   // 230
+		std::uint64_t                                    unk238;                   // 238
+		std::uint64_t                                    unk240;                   // 240
+		CombatController*                                combatController;         // 248
+		std::uint64_t                                    unk250;                   // 250
+		ActorValueStorage                                avStorage;                // 258
+		std::uint64_t                                    unk280;                   // 280
+		REX::EnumSet<ACTOR_CRITICAL_STAGE, std::int32_t> criticalStage;            // 288
+		std::uint32_t                                    dialogueItemTarget;       // 28C - TESPointerHandle
+		std::uint32_t                                    currentCombatTarget;      // 290 - TESPointerHandle
+		std::uint32_t                                    myKiller;                 // 294 - TESPointerHandle
+		std::uint64_t                                    unk298;                   // 298
+		std::uint64_t                                    unk2A0;                   // 2A0
+		std::uint32_t                                    actionValue;              // 2A8
+		float                                            timerOnAction;            // 2AC
+		std::uint64_t                                    unk2B0;                   // 2B0
+		std::uint32_t                                    intimidateBribeDayStamp;  // 2B8
+		std::uint32_t                                    unk2BC;                   // 2BC
+		std::uint64_t                                    unk2C0;                   // 2C0
+		std::uint64_t                                    unk2C8;                   // 2C8
+		std::uint64_t                                    unk2D0;                   // 2D0
+		std::uint64_t                                    unk2D8;                   // 2D8
+		std::uint64_t                                    unk2E0;                   // 2E0
+		std::uint64_t                                    unk2E8;                   // 2E8
+		std::uint64_t                                    unk2F0;                   // 2F0
+		std::uint64_t                                    unk2F8;                   // 2F8
+		std::uint64_t                                    unk300;                   // 300
+		std::uint64_t                                    unk308;                   // 308
+		std::uint64_t                                    unk310;                   // 310
+		std::uint64_t                                    unk318;                   // 318
+		std::uint64_t                                    unk320;                   // 320
+		std::uint64_t                                    unk328;                   // 328
+		std::uint64_t                                    unk330;                   // 330
+		std::uint64_t                                    unk338;                   // 338
+		std::uint64_t                                    unk340;                   // 340
+		std::uint64_t                                    unk348;                   // 348
+		TESRace*                                         race;                     // 350
+		Perks*                                           perks;                    // 358
+		std::uint32_t                                    unk360;                   // 360
+		mutable BSReadWriteLock                          perkArrayLock;            // 364
+		std::uint32_t                                    unk35C;                   // 35C
+		REX::EnumSet<BOOL_FLAGS, std::uint32_t>          boolFlags;                // 370
+		REX::EnumSet<BOOL_FLAGS2, std::uint32_t>         boolFlags2;               // 374
+		std::uint64_t                                    unk378;                   // 378
+		std::uint64_t                                    unk380;                   // 380
+		std::uint64_t                                    unk388;                   // 388
+		std::uint64_t                                    unk390;                   // 390
+		std::uint64_t                                    unk398;                   // 398
+		std::uint64_t                                    unk3A0;                   // 3A0
+		std::uint64_t                                    unk3A8;                   // 3A8
+		std::uint64_t                                    unk3B0;                   // 3B0
+		std::uint64_t                                    unk3B8;                   // 3B8
+		std::uint64_t                                    unk3C0;                   // 3C0
+		std::uint64_t                                    unk3C8;                   // 3C8
+		std::uint64_t                                    unk3D0;                   // 3D0
+		std::uint64_t                                    unk3D8;                   // 3D8
+		std::uint64_t                                    unk3E0;                   // 3E0
+		std::uint64_t                                    unk3E8;                   // 3E8
+		std::uint64_t                                    unk3F0;                   // 3F0
+		std::uint64_t                                    unk3F8;                   // 3F8
+		std::uint64_t                                    unk400;                   // 400
+		std::uint64_t                                    unk408;                   // 408
+		std::uint64_t                                    unk410;                   // 410
+		std::uint64_t                                    unk418;                   // 418
+		std::uint64_t                                    unk420;                   // 420
+		std::uint64_t                                    unk428;                   // 428
+		std::uint64_t                                    unk430;                   // 430
+		std::uint64_t                                    unk438;                   // 438
+		std::uint64_t                                    unk440;                   // 440
+		std::uint64_t                                    unk448;                   // 448
+		std::uint64_t                                    unk450;                   // 450
+		std::uint64_t                                    unk458;                   // 458
+		std::uint64_t                                    unk460;                   // 460
+		std::uint64_t                                    unk468;                   // 468
+		std::uint64_t                                    unk470;                   // 470
+		std::uint64_t                                    unk478;                   // 478
+		std::uint64_t                                    unk480;                   // 480
+		std::uint64_t                                    unk488;                   // 488
+		std::uint64_t                                    unk490;                   // 490
+		std::uint64_t                                    unk498;                   // 498
+		std::uint64_t                                    unk4A0;                   // 4A0
+		std::uint64_t                                    unk4A8;                   // 4A8
+		std::uint64_t                                    unk4B0;                   // 4B0
+		std::uint64_t                                    unk4B8;                   // 4B8
+		std::uint64_t                                    unk4C0;                   // 4C0
+		std::uint64_t                                    unk4C8;                   // 4C8
+		std::uint64_t                                    unk4D0;                   // 4D0
+		std::uint64_t                                    unk4D8;                   // 4D8
+		std::uint64_t                                    unk4E0;                   // 4E0
+		std::uint64_t                                    unk4E8;                   // 4E8
+		std::uint64_t                                    unk4F0;                   // 4F0
+		std::uint64_t                                    unk4F8;                   // 4F8
+		std::uint64_t                                    unk500;                   // 500
+		std::uint64_t                                    unk508;                   // 508
+		std::uint64_t                                    unk510;                   // 510
+		std::uint8_t                                     unk518[88];               // 518
 	};
 	static_assert(sizeof(Actor) == 0x570);
 }

--- a/include/RE/A/ActorValueInfo.h
+++ b/include/RE/A/ActorValueInfo.h
@@ -20,49 +20,48 @@ namespace RE
 		~ActorValueInfo() override;  // 00
 
 		// members
-
-		BGSEditorID                                         editorID;             // 040
-		std::uint64_t                                       unk050;               // 050
-		std::uint64_t                                       unk058;               // 058
-		std::uint64_t                                       unk060;               // 060
-		std::uint64_t                                       unk068;               // 068
-		std::uint64_t                                       unk070;               // 070
-		std::uint64_t                                       unk078;               // 078
-		std::uint64_t                                       unk080;               // 080
-		std::uint64_t                                       unk088;               // 088
-		std::uint64_t                                       unk090;               // 090
-		std::uint64_t                                       unk098;               // 098
-		std::uint64_t                                       unk0A0;               // 0A0
-		std::uint64_t                                       unk0A8;               // 0A8
-		std::uint64_t                                       unk0B0;               // 0B0
-		std::uint64_t                                       unk0B8;               // 0B8
-		std::uint64_t                                       unk0C0;               // 0C0
-		std::uint64_t                                       unk0C8;               // 0C8
-		std::uint64_t                                       unk0D0;               // 0D0
-		std::uint64_t                                       unk0D8;               // 0D8
-		std::uint64_t                                       unk0E0;               // 0E0
-		std::uint64_t                                       unk0E8;               // 0E8
-		std::uint64_t                                       unk0F0;               // 0F0
-		std::uint64_t                                       unk0F8;               // 0F8
-		std::uint64_t                                       unk100;               // 100
-		std::uint64_t                                       unk108;               // 108
-		std::uint64_t                                       unk110;               // 110
-		std::uint64_t                                       unk118;               // 118
-		std::uint64_t                                       unk120;               // 120
-		std::uint64_t                                       unk128;               // 128
-		std::uint64_t                                       unk130;               // 130
-		std::uint64_t                                       unk138;               // 138
-		BGSResource*                                        resource;             // 140
-		BSFixedString                                       abbreviation;         // 148
-		std::uint32_t                                       index;                // 150
-		std::uint32_t                                       flags;                // 154
-		stl::enumeration<ActorValue::AVType, std::uint32_t> avType;               // 158
-		std::uint32_t                                       unk15C;               // 15C
-		std::uint32_t                                       fullCacheIndex;       // 160
-		std::uint32_t                                       permanentCacheIndex;  // 164
-		std::uint64_t                                       unk168;               // 168
-		std::uint32_t                                       unk170;               // 170
-		std::uint32_t                                       sortIndex;            // 174
+		BGSEditorID      editorID;             // 040
+		std::uint64_t    unk050;               // 050
+		std::uint64_t    unk058;               // 058
+		std::uint64_t    unk060;               // 060
+		std::uint64_t    unk068;               // 068
+		std::uint64_t    unk070;               // 070
+		std::uint64_t    unk078;               // 078
+		std::uint64_t    unk080;               // 080
+		std::uint64_t    unk088;               // 088
+		std::uint64_t    unk090;               // 090
+		std::uint64_t    unk098;               // 098
+		std::uint64_t    unk0A0;               // 0A0
+		std::uint64_t    unk0A8;               // 0A8
+		std::uint64_t    unk0B0;               // 0B0
+		std::uint64_t    unk0B8;               // 0B8
+		std::uint64_t    unk0C0;               // 0C0
+		std::uint64_t    unk0C8;               // 0C8
+		std::uint64_t    unk0D0;               // 0D0
+		std::uint64_t    unk0D8;               // 0D8
+		std::uint64_t    unk0E0;               // 0E0
+		std::uint64_t    unk0E8;               // 0E8
+		std::uint64_t    unk0F0;               // 0F0
+		std::uint64_t    unk0F8;               // 0F8
+		std::uint64_t    unk100;               // 100
+		std::uint64_t    unk108;               // 108
+		std::uint64_t    unk110;               // 110
+		std::uint64_t    unk118;               // 118
+		std::uint64_t    unk120;               // 120
+		std::uint64_t    unk128;               // 128
+		std::uint64_t    unk130;               // 130
+		std::uint64_t    unk138;               // 138
+		BGSResource*     resource;             // 140
+		BSFixedString    abbreviation;         // 148
+		std::uint32_t    index;                // 150
+		std::uint32_t    flags;                // 154
+		ActorValue::Type avType;               // 158
+		std::uint32_t    unk15C;               // 15C
+		std::uint32_t    fullCacheIndex;       // 160
+		std::uint32_t    permanentCacheIndex;  // 164
+		std::uint64_t    unk168;               // 168
+		std::uint32_t    unk170;               // 170
+		std::uint32_t    sortIndex;            // 174
 	};
 	static_assert(sizeof(ActorValueInfo) == 0x178);
 }

--- a/include/RE/A/ActorValues.h
+++ b/include/RE/A/ActorValues.h
@@ -20,7 +20,7 @@ namespace RE
 		public BSTSingletonImplicit<ActorValue>  // 000
 	{
 	public:
-		enum class AVType
+		enum class Type : std::uint32_t
 		{
 			kDerivedAttribute,
 			kAttribute,

--- a/include/RE/B/BGSAimDownSightModel.h
+++ b/include/RE/B/BGSAimDownSightModel.h
@@ -45,15 +45,15 @@ namespace RE
 		const BSFixedString& GetFormDataType() override;                                                // 06 - { return "AimDownSightData"; }
 
 		// members
-		TESImageSpaceModifier*                  imod;                         // 08
-		NiPoint3                                cameraOffset;                 // 10
-		float                                   distanceFromCameraOffsetADS;  // 1C
-		float                                   fovMult;                      // 20
-		bool                                    heightDelayEnabledADS;        // 24
-		float                                   heightDelayADS;               // 28
-		bool                                    depthEnabledADS;              // 2C
-		float                                   depthDelayADS;                // 30
-		stl::enumeration<OVERLAY, std::uint8_t> overlay;                      // 34
+		TESImageSpaceModifier*              imod;                         // 08
+		NiPoint3                            cameraOffset;                 // 10
+		float                               distanceFromCameraOffsetADS;  // 1C
+		float                               fovMult;                      // 20
+		bool                                heightDelayEnabledADS;        // 24
+		float                               heightDelayADS;               // 28
+		bool                                depthEnabledADS;              // 2C
+		float                               depthDelayADS;                // 30
+		REX::EnumSet<OVERLAY, std::uint8_t> overlay;                      // 34
 	};
 	static_assert(sizeof(AimDownSightData) == 0x38);
 

--- a/include/RE/B/BGSArtObject.h
+++ b/include/RE/B/BGSArtObject.h
@@ -17,7 +17,7 @@ namespace RE
 		SF_RTTI_VTABLE(BGSArtObject);
 		SF_FORMTYPE(ARTO);
 
-		enum class ArtType
+		enum class ArtType : std::uint32_t
 		{
 			kMagicCastingArt = 0,
 			kMagicHitEffect = 1,
@@ -26,10 +26,9 @@ namespace RE
 
 		struct Data  // DNAM
 		{
-		public:
 			// members
-			stl::enumeration<ArtType, std::uint32_t> artType;  // 0
-			std::uint32_t                            unk04;    // 4
+			ArtType       artType;  // 0
+			std::uint32_t unk04;    // 4
 		};
 		static_assert(sizeof(Data) == 0x8);
 

--- a/include/RE/B/BGSAtmosphere.h
+++ b/include/RE/B/BGSAtmosphere.h
@@ -93,11 +93,11 @@ namespace RE
 
 		struct MiscSettings
 		{
-			stl::enumeration<ATMOSPHERE_TYPE, std::uint32_t> atmosphereType;      // 00
-			BSTArray<BGSResource*>                           inorganicResources;  // 08
-			TESImageSpace*                                   imageSpaceDay;       // 18
-			TESImageSpace*                                   imageSpaceNight;     // 20
-			TESClimate*                                      climateOverride;     // 28
+			REX::EnumSet<ATMOSPHERE_TYPE, std::uint32_t> atmosphereType;      // 00
+			BSTArray<BGSResource*>                       inorganicResources;  // 08
+			TESImageSpace*                               imageSpaceDay;       // 18
+			TESImageSpace*                               imageSpaceNight;     // 20
+			TESClimate*                                  climateOverride;     // 28
 		};
 		static_assert(sizeof(MiscSettings) == 0x30);
 

--- a/include/RE/B/BGSAtmosphere.h
+++ b/include/RE/B/BGSAtmosphere.h
@@ -93,11 +93,11 @@ namespace RE
 
 		struct MiscSettings
 		{
-			REX::EnumSet<ATMOSPHERE_TYPE, std::uint32_t> atmosphereType;      // 00
-			BSTArray<BGSResource*>                       inorganicResources;  // 08
-			TESImageSpace*                               imageSpaceDay;       // 18
-			TESImageSpace*                               imageSpaceNight;     // 20
-			TESClimate*                                  climateOverride;     // 28
+			REX::Enum<ATMOSPHERE_TYPE, std::uint32_t> atmosphereType;      // 00
+			BSTArray<BGSResource*>                    inorganicResources;  // 08
+			TESImageSpace*                            imageSpaceDay;       // 18
+			TESImageSpace*                            imageSpaceNight;     // 20
+			TESClimate*                               climateOverride;     // 28
 		};
 		static_assert(sizeof(MiscSettings) == 0x30);
 

--- a/include/RE/B/BGSBodyPartData.h
+++ b/include/RE/B/BGSBodyPartData.h
@@ -21,25 +21,25 @@ namespace RE
 	{
 	public:
 		// members
-		float                                                      unk00;                   // 00
-		float                                                      unk04;                   // 04
-		std::uint8_t                                               flags;                   // 08
-		stl::enumeration<BGSBodyPartDefs::LIMB_ENUM, std::uint8_t> limbEnum;                // 09
-		std::uint8_t                                               unk0A;                   // 0A
-		std::uint16_t                                              unk0C;                   // 0C
-		BGSDebris*                                                 onCrippleDebris;         // 10
-		BGSExplosion*                                              onCrippleExplosion;      // 18
-		BGSImpactDataSet*                                          onCrippleImpactDataSet;  // 20
-		ActorValueInfo*                                            actorValue;              // 28
-		BGSArtObject*                                              onCrippleArt;            // 30
-		BGSMaterialType*                                           goreEffectsMaterial;     // 38
-		BGSMaterialType*                                           onCrippleMaterial;       // 40
-		BGSBodyPartDefs::HitReactionData                           hitReactionData;         // 48
-		BSFixedString                                              unk70;                   // 70
-		BSFixedString                                              unk78;                   // 78
-		BSFixedString                                              unk80;                   // 80
-		BSFixedStringCS                                            unk88;                   // 88
-		BSFixedString                                              unk90;                   // 90
+		float                                                  unk00;                   // 00
+		float                                                  unk04;                   // 04
+		std::uint8_t                                           flags;                   // 08
+		REX::EnumSet<BGSBodyPartDefs::LIMB_ENUM, std::uint8_t> limbEnum;                // 09
+		std::uint8_t                                           unk0A;                   // 0A
+		std::uint16_t                                          unk0C;                   // 0C
+		BGSDebris*                                             onCrippleDebris;         // 10
+		BGSExplosion*                                          onCrippleExplosion;      // 18
+		BGSImpactDataSet*                                      onCrippleImpactDataSet;  // 20
+		ActorValueInfo*                                        actorValue;              // 28
+		BGSArtObject*                                          onCrippleArt;            // 30
+		BGSMaterialType*                                       goreEffectsMaterial;     // 38
+		BGSMaterialType*                                       onCrippleMaterial;       // 40
+		BGSBodyPartDefs::HitReactionData                       hitReactionData;         // 48
+		BSFixedString                                          unk70;                   // 70
+		BSFixedString                                          unk78;                   // 78
+		BSFixedString                                          unk80;                   // 80
+		BSFixedStringCS                                        unk88;                   // 88
+		BSFixedString                                          unk90;                   // 90
 	};
 	static_assert(sizeof(BGSBodyPart) == 0x98);
 

--- a/include/RE/B/BGSBodyPartData.h
+++ b/include/RE/B/BGSBodyPartData.h
@@ -21,25 +21,25 @@ namespace RE
 	{
 	public:
 		// members
-		float                                                  unk00;                   // 00
-		float                                                  unk04;                   // 04
-		std::uint8_t                                           flags;                   // 08
-		REX::EnumSet<BGSBodyPartDefs::LIMB_ENUM, std::uint8_t> limbEnum;                // 09
-		std::uint8_t                                           unk0A;                   // 0A
-		std::uint16_t                                          unk0C;                   // 0C
-		BGSDebris*                                             onCrippleDebris;         // 10
-		BGSExplosion*                                          onCrippleExplosion;      // 18
-		BGSImpactDataSet*                                      onCrippleImpactDataSet;  // 20
-		ActorValueInfo*                                        actorValue;              // 28
-		BGSArtObject*                                          onCrippleArt;            // 30
-		BGSMaterialType*                                       goreEffectsMaterial;     // 38
-		BGSMaterialType*                                       onCrippleMaterial;       // 40
-		BGSBodyPartDefs::HitReactionData                       hitReactionData;         // 48
-		BSFixedString                                          unk70;                   // 70
-		BSFixedString                                          unk78;                   // 78
-		BSFixedString                                          unk80;                   // 80
-		BSFixedStringCS                                        unk88;                   // 88
-		BSFixedString                                          unk90;                   // 90
+		float                                               unk00;                   // 00
+		float                                               unk04;                   // 04
+		std::uint8_t                                        flags;                   // 08
+		REX::Enum<BGSBodyPartDefs::LIMB_ENUM, std::uint8_t> limbEnum;                // 09
+		std::uint8_t                                        unk0A;                   // 0A
+		std::uint16_t                                       unk0C;                   // 0C
+		BGSDebris*                                          onCrippleDebris;         // 10
+		BGSExplosion*                                       onCrippleExplosion;      // 18
+		BGSImpactDataSet*                                   onCrippleImpactDataSet;  // 20
+		ActorValueInfo*                                     actorValue;              // 28
+		BGSArtObject*                                       onCrippleArt;            // 30
+		BGSMaterialType*                                    goreEffectsMaterial;     // 38
+		BGSMaterialType*                                    onCrippleMaterial;       // 40
+		BGSBodyPartDefs::HitReactionData                    hitReactionData;         // 48
+		BSFixedString                                       unk70;                   // 70
+		BSFixedString                                       unk78;                   // 78
+		BSFixedString                                       unk80;                   // 80
+		BSFixedStringCS                                     unk88;                   // 88
+		BSFixedString                                       unk90;                   // 90
 	};
 	static_assert(sizeof(BGSBodyPart) == 0x98);
 

--- a/include/RE/B/BGSCameraShot.h
+++ b/include/RE/B/BGSCameraShot.h
@@ -51,22 +51,22 @@ namespace RE
 			};
 
 			// members
-			stl::enumeration<CAM_ACTION, std::int32_t> cameraAction;                // 00
-			stl::enumeration<CAM_OBJECT, std::int32_t> location;                    // 04
-			stl::enumeration<CAM_OBJECT, std::int32_t> target;                      // 08
-			std::uint32_t                              flags;                       // 0C
-			float                                      playerTimeMult;              // 10
-			float                                      targetTimeMult;              // 14
-			float                                      globalTimeMult;              // 18
-			float                                      maxTime;                     // 1C
-			float                                      minTime;                     // 20
-			float                                      targetPercentBetweenActors;  // 24
-			float                                      nearTargetDistance;          // 28
-			float                                      locationSpring;              // 2C
-			float                                      targetSpring;                // 30
-			float                                      rotationOffsetX;             // 34
-			float                                      rotationOffsetY;             // 38
-			float                                      rotationOffsetZ;             // 3C
+			REX::EnumSet<CAM_ACTION, std::int32_t> cameraAction;                // 00
+			REX::EnumSet<CAM_OBJECT, std::int32_t> location;                    // 04
+			REX::EnumSet<CAM_OBJECT, std::int32_t> target;                      // 08
+			std::uint32_t                          flags;                       // 0C
+			float                                  playerTimeMult;              // 10
+			float                                  targetTimeMult;              // 14
+			float                                  globalTimeMult;              // 18
+			float                                  maxTime;                     // 1C
+			float                                  minTime;                     // 20
+			float                                  targetPercentBetweenActors;  // 24
+			float                                  nearTargetDistance;          // 28
+			float                                  locationSpring;              // 2C
+			float                                  targetSpring;                // 30
+			float                                  rotationOffsetX;             // 34
+			float                                  rotationOffsetY;             // 38
+			float                                  rotationOffsetZ;             // 3C
 		};
 		static_assert(sizeof(CAMERA_SHOT_DATA) == 0x40);
 

--- a/include/RE/B/BGSCameraShot.h
+++ b/include/RE/B/BGSCameraShot.h
@@ -51,22 +51,22 @@ namespace RE
 			};
 
 			// members
-			REX::EnumSet<CAM_ACTION, std::int32_t> cameraAction;                // 00
-			REX::EnumSet<CAM_OBJECT, std::int32_t> location;                    // 04
-			REX::EnumSet<CAM_OBJECT, std::int32_t> target;                      // 08
-			std::uint32_t                          flags;                       // 0C
-			float                                  playerTimeMult;              // 10
-			float                                  targetTimeMult;              // 14
-			float                                  globalTimeMult;              // 18
-			float                                  maxTime;                     // 1C
-			float                                  minTime;                     // 20
-			float                                  targetPercentBetweenActors;  // 24
-			float                                  nearTargetDistance;          // 28
-			float                                  locationSpring;              // 2C
-			float                                  targetSpring;                // 30
-			float                                  rotationOffsetX;             // 34
-			float                                  rotationOffsetY;             // 38
-			float                                  rotationOffsetZ;             // 3C
+			REX::Enum<CAM_ACTION, std::int32_t> cameraAction;                // 00
+			REX::Enum<CAM_OBJECT, std::int32_t> location;                    // 04
+			REX::Enum<CAM_OBJECT, std::int32_t> target;                      // 08
+			std::uint32_t                       flags;                       // 0C
+			float                               playerTimeMult;              // 10
+			float                               targetTimeMult;              // 14
+			float                               globalTimeMult;              // 18
+			float                               maxTime;                     // 1C
+			float                               minTime;                     // 20
+			float                               targetPercentBetweenActors;  // 24
+			float                               nearTargetDistance;          // 28
+			float                               locationSpring;              // 2C
+			float                               targetSpring;                // 30
+			float                               rotationOffsetX;             // 34
+			float                               rotationOffsetY;             // 38
+			float                               rotationOffsetZ;             // 3C
 		};
 		static_assert(sizeof(CAMERA_SHOT_DATA) == 0x40);
 

--- a/include/RE/B/BGSCollisionLayer.h
+++ b/include/RE/B/BGSCollisionLayer.h
@@ -12,7 +12,7 @@ namespace RE
 		SF_RTTI_VTABLE(BGSCollisionLayer);
 		SF_FORMTYPE(COLL);
 
-		enum class FLAG  // GNAM
+		enum class Flag  // GNAM
 		{
 			kNone = 0,
 			kTriggerVolume = 1 << 0,
@@ -23,11 +23,11 @@ namespace RE
 		~BGSCollisionLayer() override;  // 00
 
 		// members
-		std::uint32_t                         collisionIdx;  // 30
-		std::uint32_t                         debugColor;    // 34
-		stl::enumeration<FLAG, std::uint32_t> flags;         // 38
-		BSFixedString                         name;          // 40
-		BSTArray<BGSCollisionLayer*>          collidesWith;  // 48
+		std::uint32_t                     collisionIdx;  // 30
+		std::uint32_t                     debugColor;    // 34
+		REX::EnumSet<Flag, std::uint32_t> flags;         // 38
+		BSFixedString                     name;          // 40
+		BSTArray<BGSCollisionLayer*>      collidesWith;  // 48
 	};
 	static_assert(sizeof(BGSCollisionLayer) == 0x58);
 }

--- a/include/RE/B/BGSColorForm.h
+++ b/include/RE/B/BGSColorForm.h
@@ -29,9 +29,9 @@ namespace RE
 		{
 			std::uint32_t color;
 			float         remappingIndex;
-		};                                                 // 40
-		TESCondition                          conditions;  // 48
-		stl::enumeration<Flag, std::uint32_t> flags;       // 58
+		};                                             // 40
+		TESCondition                      conditions;  // 48
+		REX::EnumSet<Flag, std::uint32_t> flags;       // 58
 	};
 	static_assert(sizeof(BGSColorForm) == 0x60);
 }

--- a/include/RE/B/BGSConstructibleObject.h
+++ b/include/RE/B/BGSConstructibleObject.h
@@ -38,7 +38,7 @@ namespace RE
 		BGSCurveForm*                                                                   unk168;       // 168
 		TESGlobal*                                                                      buildLimit;   // 170
 		BSTArray<BSTTuple3<TESForm*, BGSCurveForm*, BGSTypedFormValuePair::SharedVal>>* unk178;       // 178
-		stl::enumeration<LEARN_METHOD, std::uint8_t>                                    learnMethod;  // 180
+		REX::EnumSet<LEARN_METHOD, std::uint8_t>                                        learnMethod;  // 180
 		TESGlobal*                                                                      unk188;       // 188
 		BGSKeyword*                                                                     unk190;       // 190
 		std::uint32_t                                                                   unk198;       // 198

--- a/include/RE/B/BGSConstructibleObject.h
+++ b/include/RE/B/BGSConstructibleObject.h
@@ -38,7 +38,7 @@ namespace RE
 		BGSCurveForm*                                                                   unk168;       // 168
 		TESGlobal*                                                                      buildLimit;   // 170
 		BSTArray<BSTTuple3<TESForm*, BGSCurveForm*, BGSTypedFormValuePair::SharedVal>>* unk178;       // 178
-		REX::EnumSet<LEARN_METHOD, std::uint8_t>                                        learnMethod;  // 180
+		REX::Enum<LEARN_METHOD, std::uint8_t>                                           learnMethod;  // 180
 		TESGlobal*                                                                      unk188;       // 188
 		BGSKeyword*                                                                     unk190;       // 190
 		std::uint32_t                                                                   unk198;       // 198

--- a/include/RE/B/BGSDefaultObject.h
+++ b/include/RE/B/BGSDefaultObject.h
@@ -14,9 +14,9 @@ namespace RE
 		~BGSDefaultObject() override;  // 00
 
 		// members
-		BGSEditorID                              formEditorID;  // 30
-		TESForm*                                 object;        // 40
-		stl::enumeration<FormType, std::uint8_t> objectType;    // 48
+		BGSEditorID                          formEditorID;  // 30
+		TESForm*                             object;        // 40
+		REX::EnumSet<FormType, std::uint8_t> objectType;    // 48
 	};
 	static_assert(sizeof(BGSDefaultObject) == 0x50);
 }

--- a/include/RE/B/BGSDefaultObject.h
+++ b/include/RE/B/BGSDefaultObject.h
@@ -14,9 +14,9 @@ namespace RE
 		~BGSDefaultObject() override;  // 00
 
 		// members
-		BGSEditorID                          formEditorID;  // 30
-		TESForm*                             object;        // 40
-		REX::EnumSet<FormType, std::uint8_t> objectType;    // 48
+		BGSEditorID                       formEditorID;  // 30
+		TESForm*                          object;        // 40
+		REX::Enum<FormType, std::uint8_t> objectType;    // 48
 	};
 	static_assert(sizeof(BGSDefaultObject) == 0x50);
 }

--- a/include/RE/B/BGSDefaultObjectManager.h
+++ b/include/RE/B/BGSDefaultObjectManager.h
@@ -394,11 +394,11 @@ namespace RE
 	{
 	public:
 		// members
-		const char*                                      name;           // 00
-		REX::EnumSet<FormType, std::uint8_t>             type;           // 08
-		char                                             uniqueID[4];    // 0C
-		REX::EnumSet<DEFAULT_OBJECT_TYPE, std::uint32_t> doType;         // 10
-		const char*                                      newObjectName;  // 18
+		const char*                                   name;           // 00
+		REX::Enum<FormType, std::uint8_t>             type;           // 08
+		char                                          uniqueID[4];    // 0C
+		REX::Enum<DEFAULT_OBJECT_TYPE, std::uint32_t> doType;         // 10
+		const char*                                   newObjectName;  // 18
 	};
 	static_assert(sizeof(DEFAULT_OBJECT_DATA) == 0x20);
 

--- a/include/RE/B/BGSDefaultObjectManager.h
+++ b/include/RE/B/BGSDefaultObjectManager.h
@@ -394,11 +394,11 @@ namespace RE
 	{
 	public:
 		// members
-		const char*                                          name;           // 00
-		stl::enumeration<FormType, std::uint8_t>             type;           // 08
-		char                                                 uniqueID[4];    // 0C
-		stl::enumeration<DEFAULT_OBJECT_TYPE, std::uint32_t> doType;         // 10
-		const char*                                          newObjectName;  // 18
+		const char*                                      name;           // 00
+		REX::EnumSet<FormType, std::uint8_t>             type;           // 08
+		char                                             uniqueID[4];    // 0C
+		REX::EnumSet<DEFAULT_OBJECT_TYPE, std::uint32_t> doType;         // 10
+		const char*                                      newObjectName;  // 18
 	};
 	static_assert(sizeof(DEFAULT_OBJECT_DATA) == 0x20);
 

--- a/include/RE/B/BGSDefaultObjectManager.h
+++ b/include/RE/B/BGSDefaultObjectManager.h
@@ -428,7 +428,7 @@ namespace RE
 		[[nodiscard]] TESForm* GetDefaultObject(DEFAULT_OBJECT a_obj) const noexcept
 		{
 			assert(a_obj < DEFAULT_OBJECT::kTotal);
-			return objectArray[stl::to_underlying(a_obj)];
+			return objectArray[std::to_underlying(a_obj)];
 		}
 
 		template <class T>

--- a/include/RE/B/BGSEquipSlot.h
+++ b/include/RE/B/BGSEquipSlot.h
@@ -25,10 +25,10 @@ namespace RE
 		~BGSEquipSlot() override;  // 00
 
 		// members
-		BGSEditorID                           formEditorID;         // 30
-		BSTArray<BGSEquipSlot*>               parentSlots;          // 40
-		ActorValueInfo*                       conditionActorValue;  // 50
-		stl::enumeration<Flag, std::uint32_t> flags;                // 58
+		BGSEditorID                       formEditorID;         // 30
+		BSTArray<BGSEquipSlot*>           parentSlots;          // 40
+		ActorValueInfo*                   conditionActorValue;  // 50
+		REX::EnumSet<Flag, std::uint32_t> flags;                // 58
 	};
 	static_assert(sizeof(BGSEquipSlot) == 0x60);
 }

--- a/include/RE/B/BGSForceData.h
+++ b/include/RE/B/BGSForceData.h
@@ -32,18 +32,18 @@ namespace RE
 		~BGSForceData() override;  // 00
 
 		// members
-		REX::EnumSet<BSForces::TYPE, std::uint32_t>    forceType;                     // 30
-		REX::EnumSet<BSForces::CHANNEL, std::uint32_t> forceChannel;                  // 34
-		float                                          horizontalAngle;               // 38
-		float                                          verticalAngle;                 // 3C
-		float                                          speed;                         // 40
-		float                                          strength;                      // 44
-		REX::W32::XMFLOAT3                             vector;                        // 48
-		BGSCurveForm*                                  falloffCurve;                  // 58
-		float                                          turbulenceSpeedAmplitude;      // 60
-		float                                          turbulenceSpeedFrequency;      // 64
-		float                                          turbulenceDirectionAmplitude;  // 68
-		float                                          turbulenceDirectionFrequency;  // 6C
+		REX::Enum<BSForces::TYPE, std::uint32_t>    forceType;                     // 30
+		REX::Enum<BSForces::CHANNEL, std::uint32_t> forceChannel;                  // 34
+		float                                       horizontalAngle;               // 38
+		float                                       verticalAngle;                 // 3C
+		float                                       speed;                         // 40
+		float                                       strength;                      // 44
+		REX::W32::XMFLOAT3                          vector;                        // 48
+		BGSCurveForm*                               falloffCurve;                  // 58
+		float                                       turbulenceSpeedAmplitude;      // 60
+		float                                       turbulenceSpeedFrequency;      // 64
+		float                                       turbulenceDirectionAmplitude;  // 68
+		float                                       turbulenceDirectionFrequency;  // 6C
 	};
 	static_assert(sizeof(BGSForceData) == 0x70);
 }

--- a/include/RE/B/BGSForceData.h
+++ b/include/RE/B/BGSForceData.h
@@ -32,18 +32,18 @@ namespace RE
 		~BGSForceData() override;  // 00
 
 		// members
-		stl::enumeration<BSForces::TYPE, std::uint32_t>    forceType;                     // 30
-		stl::enumeration<BSForces::CHANNEL, std::uint32_t> forceChannel;                  // 34
-		float                                              horizontalAngle;               // 38
-		float                                              verticalAngle;                 // 3C
-		float                                              speed;                         // 40
-		float                                              strength;                      // 44
-		REX::W32::XMFLOAT3                                 vector;                        // 48
-		BGSCurveForm*                                      falloffCurve;                  // 58
-		float                                              turbulenceSpeedAmplitude;      // 60
-		float                                              turbulenceSpeedFrequency;      // 64
-		float                                              turbulenceDirectionAmplitude;  // 68
-		float                                              turbulenceDirectionFrequency;  // 6C
+		REX::EnumSet<BSForces::TYPE, std::uint32_t>    forceType;                     // 30
+		REX::EnumSet<BSForces::CHANNEL, std::uint32_t> forceChannel;                  // 34
+		float                                          horizontalAngle;               // 38
+		float                                          verticalAngle;                 // 3C
+		float                                          speed;                         // 40
+		float                                          strength;                      // 44
+		REX::W32::XMFLOAT3                             vector;                        // 48
+		BGSCurveForm*                                  falloffCurve;                  // 58
+		float                                          turbulenceSpeedAmplitude;      // 60
+		float                                          turbulenceSpeedFrequency;      // 64
+		float                                          turbulenceDirectionAmplitude;  // 68
+		float                                          turbulenceDirectionFrequency;  // 6C
 	};
 	static_assert(sizeof(BGSForceData) == 0x70);
 }

--- a/include/RE/B/BGSHeadPart.h
+++ b/include/RE/B/BGSHeadPart.h
@@ -48,18 +48,18 @@ namespace RE
 		};
 
 		// members
-		BGSEditorID                               formEditorID;       // 068
-		TESModel                                  chargenModel;       // 078
-		TESModelTri                               morphs[3];          // 098
-		TESCondition                              chargenConditions;  // 0F8
-		BSTArray<BGSHeadPart*>                    extraParts;         // 108
-		BGSMorphableObject*                       morphableObject;    // 118
-		BGSTextureSet*                            textureSet;         // 120
-		BGSListForm*                              validRaces;         // 128
-		BSFixedString                             colorMapping;       // 130
-		BSFixedString                             mask;               // 138
-		REX::EnumSet<HeadPartType, std::uint32_t> type;               // 140
-		std::uint32_t                             unk144;             // 144
+		BGSEditorID                            formEditorID;       // 068
+		TESModel                               chargenModel;       // 078
+		TESModelTri                            morphs[3];          // 098
+		TESCondition                           chargenConditions;  // 0F8
+		BSTArray<BGSHeadPart*>                 extraParts;         // 108
+		BGSMorphableObject*                    morphableObject;    // 118
+		BGSTextureSet*                         textureSet;         // 120
+		BGSListForm*                           validRaces;         // 128
+		BSFixedString                          colorMapping;       // 130
+		BSFixedString                          mask;               // 138
+		REX::Enum<HeadPartType, std::uint32_t> type;               // 140
+		std::uint32_t                          unk144;             // 144
 	};
 	static_assert(sizeof(BGSHeadPart) == 0x148);
 }

--- a/include/RE/B/BGSHeadPart.h
+++ b/include/RE/B/BGSHeadPart.h
@@ -48,18 +48,18 @@ namespace RE
 		};
 
 		// members
-		BGSEditorID                                   formEditorID;       // 068
-		TESModel                                      chargenModel;       // 078
-		TESModelTri                                   morphs[3];          // 098
-		TESCondition                                  chargenConditions;  // 0F8
-		BSTArray<BGSHeadPart*>                        extraParts;         // 108
-		BGSMorphableObject*                           morphableObject;    // 118
-		BGSTextureSet*                                textureSet;         // 120
-		BGSListForm*                                  validRaces;         // 128
-		BSFixedString                                 colorMapping;       // 130
-		BSFixedString                                 mask;               // 138
-		stl::enumeration<HeadPartType, std::uint32_t> type;               // 140
-		std::uint32_t                                 unk144;             // 144
+		BGSEditorID                               formEditorID;       // 068
+		TESModel                                  chargenModel;       // 078
+		TESModelTri                               morphs[3];          // 098
+		TESCondition                              chargenConditions;  // 0F8
+		BSTArray<BGSHeadPart*>                    extraParts;         // 108
+		BGSMorphableObject*                       morphableObject;    // 118
+		BGSTextureSet*                            textureSet;         // 120
+		BGSListForm*                              validRaces;         // 128
+		BSFixedString                             colorMapping;       // 130
+		BSFixedString                             mask;               // 138
+		REX::EnumSet<HeadPartType, std::uint32_t> type;               // 140
+		std::uint32_t                             unk144;             // 144
 	};
 	static_assert(sizeof(BGSHeadPart) == 0x148);
 }

--- a/include/RE/B/BGSImpactData.h
+++ b/include/RE/B/BGSImpactData.h
@@ -37,13 +37,13 @@ namespace RE
 				kNoDecalData = 1 << 0
 			};
 
-			float                                    effectDuration;   // 00
-			REX::EnumSet<ORIENTATION, std::uint32_t> orient;           // 04
-			float                                    angleThreshold;   // 08
-			float                                    placementRadius;  // 0C
-			std::uint32_t                            soundLevel;       // 10
-			REX::EnumSet<Flag, std::uint8_t>         flags;            // 14
-			REX::EnumSet<ImpactResult, std::uint8_t> resultOverride;   // 15
+			float                                 effectDuration;   // 00
+			REX::Enum<ORIENTATION, std::uint32_t> orient;           // 04
+			float                                 angleThreshold;   // 08
+			float                                 placementRadius;  // 0C
+			std::uint32_t                         soundLevel;       // 10
+			REX::EnumSet<Flag, std::uint8_t>      flags;            // 14
+			REX::Enum<ImpactResult, std::uint8_t> resultOverride;   // 15
 		};
 		static_assert(sizeof(IMPACT_DATA_DATA) == 0x18);
 

--- a/include/RE/B/BGSImpactData.h
+++ b/include/RE/B/BGSImpactData.h
@@ -37,13 +37,13 @@ namespace RE
 				kNoDecalData = 1 << 0
 			};
 
-			float                                        effectDuration;   // 00
-			stl::enumeration<ORIENTATION, std::uint32_t> orient;           // 04
-			float                                        angleThreshold;   // 08
-			float                                        placementRadius;  // 0C
-			std::uint32_t                                soundLevel;       // 10
-			stl::enumeration<Flag, std::uint8_t>         flags;            // 14
-			stl::enumeration<ImpactResult, std::uint8_t> resultOverride;   // 15
+			float                                    effectDuration;   // 00
+			REX::EnumSet<ORIENTATION, std::uint32_t> orient;           // 04
+			float                                    angleThreshold;   // 08
+			float                                    placementRadius;  // 0C
+			std::uint32_t                            soundLevel;       // 10
+			REX::EnumSet<Flag, std::uint8_t>         flags;            // 14
+			REX::EnumSet<ImpactResult, std::uint8_t> resultOverride;   // 15
 		};
 		static_assert(sizeof(IMPACT_DATA_DATA) == 0x18);
 

--- a/include/RE/B/BGSInstanceNamingRules.h
+++ b/include/RE/B/BGSInstanceNamingRules.h
@@ -37,9 +37,9 @@ namespace RE
 		~BGSInstanceNamingRules() override;  // 00
 
 		// members
-		stl::enumeration<FormType, std::uint8_t> type;          // 30
-		RuleSet                                  rules[10];     // 38
-		BSTArray<const BGSInstanceNamingRules*>  mergeSources;  // D8
+		REX::EnumSet<FormType, std::uint8_t>    type;          // 30
+		RuleSet                                 rules[10];     // 38
+		BSTArray<const BGSInstanceNamingRules*> mergeSources;  // D8
 	};
 	static_assert(sizeof(BGSInstanceNamingRules) == 0xE8);
 }

--- a/include/RE/B/BGSInstanceNamingRules.h
+++ b/include/RE/B/BGSInstanceNamingRules.h
@@ -37,7 +37,7 @@ namespace RE
 		~BGSInstanceNamingRules() override;  // 00
 
 		// members
-		REX::EnumSet<FormType, std::uint8_t>    type;          // 30
+		REX::Enum<FormType, std::uint8_t>       type;          // 30
 		RuleSet                                 rules[10];     // 38
 		BSTArray<const BGSInstanceNamingRules*> mergeSources;  // D8
 	};

--- a/include/RE/B/BGSInventoryItem.h
+++ b/include/RE/B/BGSInventoryItem.h
@@ -35,11 +35,11 @@ namespace RE
 		[[nodiscard]] bool IsEquipped() const noexcept { return flags.any(Flag::kSlotMask); }
 
 		// members
-		TESBoundObject*                       object;        // 00
-		BSTSmartPointer<TBO_InstanceData>     instanceData;  // 08
-		BSTArray<Stack>                       stacks;        // 10
-		stl::enumeration<Flag, std::uint32_t> flags;         // 20
-		std::int8_t                           unk24;         // 24
+		TESBoundObject*                   object;        // 00
+		BSTSmartPointer<TBO_InstanceData> instanceData;  // 08
+		BSTArray<Stack>                   stacks;        // 10
+		REX::EnumSet<Flag, std::uint32_t> flags;         // 20
+		std::int8_t                       unk24;         // 24
 	};
 	static_assert(sizeof(BGSInventoryItem) == 0x28);
 }

--- a/include/RE/B/BGSLocation.h
+++ b/include/RE/B/BGSLocation.h
@@ -48,7 +48,7 @@ namespace RE
 		TESForm*                                            unk098;                  // 098
 		std::uint8_t                                        unk0A0;                  // 0A0
 		std::uint8_t                                        minLevel;                // 0A1
-		stl::enumeration<Flags, std::uint8_t>               flags;                   // 0A2
+		REX::EnumSet<Flags, std::uint8_t>                   flags;                   // 0A2
 		std::uint8_t                                        maxLevel;                // 0A3
 		std::uint8_t                                        unk0A4;                  // 0A4
 		std::uint64_t                                       unk0A8;                  // 0A8

--- a/include/RE/B/BGSMaterialType.h
+++ b/include/RE/B/BGSMaterialType.h
@@ -26,14 +26,14 @@ namespace RE
 		~BGSMaterialType() override;  // 00
 
 		// members
-		TESModel                              breakableFXModel;    // 30
-		BGSMaterialType*                      parentType;          // 50
-		BGSImpactDataSet*                     havokImpactDataSet;  // 58
-		BSFixedString                         materialName;        // 60
-		std::uint32_t                         materialID;          // 68
-		NiColor                               materialColor;       // 6C
-		float                                 buoyancy;            // 78
-		stl::enumeration<FLAG, std::uint32_t> flags;               // 7C
+		TESModel                          breakableFXModel;    // 30
+		BGSMaterialType*                  parentType;          // 50
+		BGSImpactDataSet*                 havokImpactDataSet;  // 58
+		BSFixedString                     materialName;        // 60
+		std::uint32_t                     materialID;          // 68
+		NiColor                           materialColor;       // 6C
+		float                             buoyancy;            // 78
+		REX::EnumSet<FLAG, std::uint32_t> flags;               // 7C
 	};
 	static_assert(sizeof(BGSMaterialType) == 0x80);
 }

--- a/include/RE/B/BGSMessage.h
+++ b/include/RE/B/BGSMessage.h
@@ -30,7 +30,6 @@ namespace RE
 
 		struct MESSAGEBOX_BUTTON
 		{
-		public:
 			SF_HEAP_REDEFINE_NEW(MESSAGEBOX_BUTTON);
 
 			// members
@@ -44,14 +43,14 @@ namespace RE
 		~BGSMessage() override;  // 00
 
 		// members
-		TESQuest*                                    ownerQuest;   // 58
-		BSTArray<MESSAGEBOX_BUTTON*>                 menuButtons;  // 60
-		BSFixedStringCS                              unk70;        // 70
-		BGSLocalizedString                           shortName;    // 78
-		stl::enumeration<MessageFlag, std::uint32_t> flags;        // 80
-		std::uint32_t                                displayTime;  // 84
-		std::int32_t                                 unk88;        // 88
-		BSFixedStringCS                              unk90;        // 90
+		TESQuest*                                ownerQuest;   // 58
+		BSTArray<MESSAGEBOX_BUTTON*>             menuButtons;  // 60
+		BSFixedStringCS                          unk70;        // 70
+		BGSLocalizedString                       shortName;    // 78
+		REX::EnumSet<MessageFlag, std::uint32_t> flags;        // 80
+		std::uint32_t                            displayTime;  // 84
+		std::int32_t                             unk88;        // 88
+		BSFixedStringCS                          unk90;        // 90
 	};
 	static_assert(sizeof(BGSMessage) == 0x98);
 }

--- a/include/RE/B/BGSMod.h
+++ b/include/RE/B/BGSMod.h
@@ -39,9 +39,9 @@ namespace RE::BGSMod
 
 				struct Include
 				{
-					RE::BGSMod::Attachment::Mod*                 mod;
-					std::uint8_t                                 level;
-					stl::enumeration<IncludesFlag, std::uint8_t> flags;
+					RE::BGSMod::Attachment::Mod*             mod;
+					std::uint8_t                             level;
+					REX::EnumSet<IncludesFlag, std::uint8_t> flags;
 				};
 				static_assert(sizeof(Include) == 0x10);
 

--- a/include/RE/B/BGSPhotoModeFeature.h
+++ b/include/RE/B/BGSPhotoModeFeature.h
@@ -26,14 +26,14 @@ namespace RE
 
 		struct Feature
 		{
-			REX::EnumSet<TYPE, std::uint8_t> type;     // 00
-			float                            offsetX;  // 04
-			float                            offsetY;  // 08
-			float                            unk0C;    // 0C
-			float                            unk10;    // 10
-			float                            width;    // 14
-			float                            height;   // 18
-			float                            unk1C;    // 1C
+			REX::Enum<TYPE, std::uint8_t> type;     // 00
+			float                         offsetX;  // 04
+			float                         offsetY;  // 08
+			float                         unk0C;    // 0C
+			float                         unk10;    // 10
+			float                         width;    // 14
+			float                         height;   // 18
+			float                         unk1C;    // 1C
 		};
 		static_assert(sizeof(Feature) == 0x20);
 

--- a/include/RE/B/BGSPhotoModeFeature.h
+++ b/include/RE/B/BGSPhotoModeFeature.h
@@ -26,14 +26,14 @@ namespace RE
 
 		struct Feature
 		{
-			stl::enumeration<TYPE, std::uint8_t> type;     // 00
-			float                                offsetX;  // 04
-			float                                offsetY;  // 08
-			float                                unk0C;    // 0C
-			float                                unk10;    // 10
-			float                                width;    // 14
-			float                                height;   // 18
-			float                                unk1C;    // 1C
+			REX::EnumSet<TYPE, std::uint8_t> type;     // 00
+			float                            offsetX;  // 04
+			float                            offsetY;  // 08
+			float                            unk0C;    // 0C
+			float                            unk10;    // 10
+			float                            width;    // 14
+			float                            height;   // 18
+			float                            unk1C;    // 1C
 		};
 		static_assert(sizeof(Feature) == 0x20);
 

--- a/include/RE/B/BGSProjectile.h
+++ b/include/RE/B/BGSProjectile.h
@@ -50,36 +50,36 @@ namespace RE
 		};
 
 		// members
-		BSFixedString                                       unk00;                // 00
-		BSFixedString                                       unk08;                // 08
-		TESObjectLIGH*                                      light;                // 10
-		TESObjectLIGH*                                      muzzleFlashLight;     // 18
-		BGSExplosion*                                       explosionType;        // 20
-		TESObjectWEAP*                                      defaultWeaponSource;  // 28
-		BGSTextureSet*                                      decalData;            // 30
-		BGSCollisionLayer*                                  collisionLayer;       // 38
-		BGSProjectile*                                      vatsProjectile;       // 40
-		stl::enumeration<BGSProjectileFlags, std::uint32_t> flags;                // 48
-		float                                               gravity;              // 4C
-		float                                               speed;                // 50
-		float                                               range;                // 54
-		float                                               explosionProximity;   // 58
-		float                                               explosionTimer;       // 5C
-		float                                               muzzleFlashDuration;  // 60
-		float                                               fadeOutTime;          // 64
-		float                                               force;                // 68
-		float                                               coneSpread;           // 6C
-		float                                               collisionRadius;      // 70
-		float                                               lifetime;             // 74
-		float                                               relaunchInterval;     // 78
-		float                                               unk7C;                // 7C
-		std::uint32_t                                       unk80;                // 80
-		stl::enumeration<Type, std::uint8_t>                type;                 // 84
-		std::uint8_t                                        unk85;                // 85
-		float                                               unk88;                // 88
-		float                                               unk8C;                // 8C
-		float                                               unk90;                // 90
-		float                                               unk94;                // 94
+		BSFixedString                                   unk00;                // 00
+		BSFixedString                                   unk08;                // 08
+		TESObjectLIGH*                                  light;                // 10
+		TESObjectLIGH*                                  muzzleFlashLight;     // 18
+		BGSExplosion*                                   explosionType;        // 20
+		TESObjectWEAP*                                  defaultWeaponSource;  // 28
+		BGSTextureSet*                                  decalData;            // 30
+		BGSCollisionLayer*                              collisionLayer;       // 38
+		BGSProjectile*                                  vatsProjectile;       // 40
+		REX::EnumSet<BGSProjectileFlags, std::uint32_t> flags;                // 48
+		float                                           gravity;              // 4C
+		float                                           speed;                // 50
+		float                                           range;                // 54
+		float                                           explosionProximity;   // 58
+		float                                           explosionTimer;       // 5C
+		float                                           muzzleFlashDuration;  // 60
+		float                                           fadeOutTime;          // 64
+		float                                           force;                // 68
+		float                                           coneSpread;           // 6C
+		float                                           collisionRadius;      // 70
+		float                                           lifetime;             // 74
+		float                                           relaunchInterval;     // 78
+		float                                           unk7C;                // 7C
+		std::uint32_t                                   unk80;                // 80
+		REX::EnumSet<Type, std::uint8_t>                type;                 // 84
+		std::uint8_t                                    unk85;                // 85
+		float                                           unk88;                // 88
+		float                                           unk8C;                // 8C
+		float                                           unk90;                // 90
+		float                                           unk94;                // 94
 	};
 	static_assert(sizeof(BGSProjectileData) == 0x98);
 

--- a/include/RE/B/BGSReverbParameters.h
+++ b/include/RE/B/BGSReverbParameters.h
@@ -24,8 +24,8 @@ namespace RE
 		~BGSReverbParameters() override;  // 00
 
 		// members
-		stl::enumeration<ReverbClass, std::uint32_t> reverbClass;  // 30
-		BGSAudio::WwiseGUID                          audioBus;     // 38
+		REX::EnumSet<ReverbClass, std::uint32_t> reverbClass;  // 30
+		BGSAudio::WwiseGUID                      audioBus;     // 38
 	};
 	static_assert(sizeof(BGSReverbParameters) == 0x48);
 }

--- a/include/RE/B/BGSReverbParameters.h
+++ b/include/RE/B/BGSReverbParameters.h
@@ -24,8 +24,8 @@ namespace RE
 		~BGSReverbParameters() override;  // 00
 
 		// members
-		REX::EnumSet<ReverbClass, std::uint32_t> reverbClass;  // 30
-		BGSAudio::WwiseGUID                      audioBus;     // 38
+		REX::Enum<ReverbClass, std::uint32_t> reverbClass;  // 30
+		BGSAudio::WwiseGUID                   audioBus;     // 38
 	};
 	static_assert(sizeof(BGSReverbParameters) == 0x48);
 }

--- a/include/RE/B/BGSVoiceType.h
+++ b/include/RE/B/BGSVoiceType.h
@@ -18,8 +18,8 @@ namespace RE
 		};
 
 		// members
-		stl::enumeration<Flag, std::uint8_t> flags;  // 0
-		std::uint8_t                         unk01;  // 1
+		REX::EnumSet<Flag, std::uint8_t> flags;  // 0
+		std::uint8_t                     unk01;  // 1
 	};
 	static_assert(sizeof(VOICE_TYPE_DATA) == 0x2);
 

--- a/include/RE/B/BGSWeatherSettingsForm.h
+++ b/include/RE/B/BGSWeatherSettingsForm.h
@@ -77,10 +77,10 @@ namespace RE
 				kThunder
 			};
 
-			BGSAudio::WwiseSoundHook               soundHook;  // 00
-			REX::EnumSet<SoundType, std::uint32_t> type;       // 30
-			float                                  minDelay;   // 34
-			float                                  maxDelay;   // 38
+			BGSAudio::WwiseSoundHook            soundHook;  // 00
+			REX::Enum<SoundType, std::uint32_t> type;       // 30
+			float                               minDelay;   // 34
+			float                               maxDelay;   // 38
 		};
 		static_assert(sizeof(WeatherSound) == 0x40);
 

--- a/include/RE/B/BGSWeatherSettingsForm.h
+++ b/include/RE/B/BGSWeatherSettingsForm.h
@@ -77,10 +77,10 @@ namespace RE
 				kThunder
 			};
 
-			BGSAudio::WwiseSoundHook                   soundHook;  // 00
-			stl::enumeration<SoundType, std::uint32_t> type;       // 30
-			float                                      minDelay;   // 34
-			float                                      maxDelay;   // 38
+			BGSAudio::WwiseSoundHook               soundHook;  // 00
+			REX::EnumSet<SoundType, std::uint32_t> type;       // 30
+			float                                  minDelay;   // 34
+			float                                  maxDelay;   // 38
 		};
 		static_assert(sizeof(WeatherSound) == 0x40);
 

--- a/include/RE/B/BSBlendable.h
+++ b/include/RE/B/BSBlendable.h
@@ -16,9 +16,9 @@ namespace RE::BSBlendable
 	{
 	public:
 		// members
-		stl::enumeration<BlendOp, std::uint32_t> op;           // 00
-		REX::W32::XMFLOAT4                       value;        // 04
-		float                                    blendAmount;  // 14
+		REX::EnumSet<BlendOp, std::uint32_t> op;           // 00
+		REX::W32::XMFLOAT4                   value;        // 04
+		float                                blendAmount;  // 14
 	};
 	static_assert(sizeof(ColorValue) == 0x18);
 
@@ -26,9 +26,9 @@ namespace RE::BSBlendable
 	{
 	public:
 		// members
-		stl::enumeration<BlendOp, std::uint32_t> op;          // 0
-		float                                    value;       // 4
-		float                                    blendValue;  // 8
+		REX::EnumSet<BlendOp, std::uint32_t> op;          // 0
+		float                                value;       // 4
+		float                                blendValue;  // 8
 	};
 	static_assert(sizeof(FloatValue) == 0xC);
 }

--- a/include/RE/B/BSBlendable.h
+++ b/include/RE/B/BSBlendable.h
@@ -16,9 +16,9 @@ namespace RE::BSBlendable
 	{
 	public:
 		// members
-		REX::EnumSet<BlendOp, std::uint32_t> op;           // 00
-		REX::W32::XMFLOAT4                   value;        // 04
-		float                                blendAmount;  // 14
+		REX::Enum<BlendOp, std::uint32_t> op;           // 00
+		REX::W32::XMFLOAT4                value;        // 04
+		float                             blendAmount;  // 14
 	};
 	static_assert(sizeof(ColorValue) == 0x18);
 
@@ -26,9 +26,9 @@ namespace RE::BSBlendable
 	{
 	public:
 		// members
-		REX::EnumSet<BlendOp, std::uint32_t> op;          // 0
-		float                                value;       // 4
-		float                                blendValue;  // 8
+		REX::Enum<BlendOp, std::uint32_t> op;          // 0
+		float                             value;       // 4
+		float                             blendValue;  // 8
 	};
 	static_assert(sizeof(FloatValue) == 0xC);
 }

--- a/include/RE/B/BSExtraData.h
+++ b/include/RE/B/BSExtraData.h
@@ -21,9 +21,9 @@ namespace RE
 		virtual void Unk_06();  // 06
 
 		// members
-		BSExtraData*                                  next;   // 08
-		std::uint16_t                                 flags;  // 10
-		stl::enumeration<ExtraDataType, std::uint8_t> type;   // 12
+		BSExtraData*                              next;   // 08
+		std::uint16_t                             flags;  // 10
+		REX::EnumSet<ExtraDataType, std::uint8_t> type;   // 12
 	};
 	static_assert(sizeof(BSExtraData) == 0x18);
 }

--- a/include/RE/B/BSExtraData.h
+++ b/include/RE/B/BSExtraData.h
@@ -21,9 +21,9 @@ namespace RE
 		virtual void Unk_06();  // 06
 
 		// members
-		BSExtraData*                              next;   // 08
-		std::uint16_t                             flags;  // 10
-		REX::EnumSet<ExtraDataType, std::uint8_t> type;   // 12
+		BSExtraData*                           next;   // 08
+		std::uint16_t                          flags;  // 10
+		REX::Enum<ExtraDataType, std::uint8_t> type;   // 12
 	};
 	static_assert(sizeof(BSExtraData) == 0x18);
 }

--- a/include/RE/B/BSFloatCurve.h
+++ b/include/RE/B/BSFloatCurve.h
@@ -31,17 +31,17 @@ namespace RE
 		static_assert(sizeof(Control) == 0x8);
 
 		// members
-		std::uint64_t                             unk00;                  // 00
-		std::vector<Control>                      controls;               // 08 - std::vector<BSFloatCurve::Control, BSTHeapAllocator<BSFloatCurve::Control, 2>>
-		float                                     maxInput;               // 20
-		float                                     minInput;               // 24
-		float                                     inputDistance;          // 28
-		float                                     maxValue;               // 2C
-		float                                     minValue;               // 30
-		float                                     defaultValue;           // 34
-		stl::enumeration<CurveType, std::uint8_t> type;                   // 38
-		stl::enumeration<Edge, std::uint8_t>      edge;                   // 39
-		bool                                      isSampleInterpolating;  // 3A
+		std::uint64_t                         unk00;                  // 00
+		std::vector<Control>                  controls;               // 08 - std::vector<BSFloatCurve::Control, BSTHeapAllocator<BSFloatCurve::Control, 2>>
+		float                                 maxInput;               // 20
+		float                                 minInput;               // 24
+		float                                 inputDistance;          // 28
+		float                                 maxValue;               // 2C
+		float                                 minValue;               // 30
+		float                                 defaultValue;           // 34
+		REX::EnumSet<CurveType, std::uint8_t> type;                   // 38
+		REX::EnumSet<Edge, std::uint8_t>      edge;                   // 39
+		bool                                  isSampleInterpolating;  // 3A
 	};
 	static_assert(sizeof(BSFloatCurve) == 0x40);
 }

--- a/include/RE/B/BSFloatCurve.h
+++ b/include/RE/B/BSFloatCurve.h
@@ -31,17 +31,17 @@ namespace RE
 		static_assert(sizeof(Control) == 0x8);
 
 		// members
-		std::uint64_t                         unk00;                  // 00
-		std::vector<Control>                  controls;               // 08 - std::vector<BSFloatCurve::Control, BSTHeapAllocator<BSFloatCurve::Control, 2>>
-		float                                 maxInput;               // 20
-		float                                 minInput;               // 24
-		float                                 inputDistance;          // 28
-		float                                 maxValue;               // 2C
-		float                                 minValue;               // 30
-		float                                 defaultValue;           // 34
-		REX::EnumSet<CurveType, std::uint8_t> type;                   // 38
-		REX::EnumSet<Edge, std::uint8_t>      edge;                   // 39
-		bool                                  isSampleInterpolating;  // 3A
+		std::uint64_t                      unk00;                  // 00
+		std::vector<Control>               controls;               // 08 - std::vector<BSFloatCurve::Control, BSTHeapAllocator<BSFloatCurve::Control, 2>>
+		float                              maxInput;               // 20
+		float                              minInput;               // 24
+		float                              inputDistance;          // 28
+		float                              maxValue;               // 2C
+		float                              minValue;               // 30
+		float                              defaultValue;           // 34
+		REX::Enum<CurveType, std::uint8_t> type;                   // 38
+		REX::Enum<Edge, std::uint8_t>      edge;                   // 39
+		bool                               isSampleInterpolating;  // 3A
 	};
 	static_assert(sizeof(BSFloatCurve) == 0x40);
 }

--- a/include/RE/C/CodeTasklet.h
+++ b/include/RE/C/CodeTasklet.h
@@ -73,7 +73,7 @@ namespace RE::BSScript
 				kTRY_LOCK_GUARDS,
 			};
 
-			enum class ResumeReason
+			enum class ResumeReason : std::uint32_t
 			{
 				kNotResuming = 0,
 				kNotResumingNoIncrement = 1,
@@ -96,20 +96,20 @@ namespace RE::BSScript
 			virtual BSTSmartPointer<Object> GetSelfAsObject() const override;  // 02
 
 			// members
-			Stack*                                        stack;                    // 10
-			VirtualMachine*                               vm;                       // 18
-			ErrorLogger*                                  errorLogger;              // 20
-			stl::enumeration<ResumeReason, std::uint32_t> resumeReason;             // 28
-			std::uint32_t                                 pad2C;                    // 2C
-			const void*                                   instructionDataStart;     // 30
-			StackFrame*                                   topFrame;                 // 38
-			std::uint32_t                                 frameMemoryPage;          // 40
-			std::uint32_t                                 instructionDataBitCount;  // 44
-			std::int8_t                                   jumpBitCount;             // 48
-			std::int8_t                                   localVarBitCount;         // 49
-			std::int8_t                                   memberVarBitCount;        // 4A
-			std::int8_t                                   unk4B;                    // 4B
-			std::uint32_t                                 pad4C;                    // 4C
+			Stack*          stack;                    // 10
+			VirtualMachine* vm;                       // 18
+			ErrorLogger*    errorLogger;              // 20
+			ResumeReason    resumeReason;             // 28
+			std::uint32_t   pad2C;                    // 2C
+			const void*     instructionDataStart;     // 30
+			StackFrame*     topFrame;                 // 38
+			std::uint32_t   frameMemoryPage;          // 40
+			std::uint32_t   instructionDataBitCount;  // 44
+			std::int8_t     jumpBitCount;             // 48
+			std::int8_t     localVarBitCount;         // 49
+			std::int8_t     memberVarBitCount;        // 4A
+			std::int8_t     unk4B;                    // 4B
+			std::uint32_t   pad4C;                    // 4C
 		};
 		static_assert(sizeof(CodeTasklet) == 0x50);
 	}

--- a/include/RE/C/ConeProjectile.h
+++ b/include/RE/C/ConeProjectile.h
@@ -13,13 +13,13 @@ namespace RE
 		~ConeProjectile() override;  // 00
 
 		// members
-		REX::EnumSet<ImpactResult, std::int32_t> impactResult;                  // 260
-		float                                    environmentTimer;              // 264
-		float                                    coneSpreadTangent;             // 268
-		float                                    initialCollisionSphereRadius;  // 26C
-		Location                                 origin;                        // 270
-		void*                                    collisionShape;                // 288
-		BSTArray<std::int32_t>                   collisions;                    // 290
+		REX::Enum<ImpactResult, std::int32_t> impactResult;                  // 260
+		float                                 environmentTimer;              // 264
+		float                                 coneSpreadTangent;             // 268
+		float                                 initialCollisionSphereRadius;  // 26C
+		Location                              origin;                        // 270
+		void*                                 collisionShape;                // 288
+		BSTArray<std::int32_t>                collisions;                    // 290
 	};
 	static_assert(sizeof(ConeProjectile) == 0x280);
 }

--- a/include/RE/C/ConeProjectile.h
+++ b/include/RE/C/ConeProjectile.h
@@ -13,13 +13,13 @@ namespace RE
 		~ConeProjectile() override;  // 00
 
 		// members
-		stl::enumeration<ImpactResult, std::int32_t> impactResult;                  // 260
-		float                                        environmentTimer;              // 264
-		float                                        coneSpreadTangent;             // 268
-		float                                        initialCollisionSphereRadius;  // 26C
-		Location                                     origin;                        // 270
-		void*                                        collisionShape;                // 288
-		BSTArray<std::int32_t>                       collisions;                    // 290
+		REX::EnumSet<ImpactResult, std::int32_t> impactResult;                  // 260
+		float                                    environmentTimer;              // 264
+		float                                    coneSpreadTangent;             // 268
+		float                                    initialCollisionSphereRadius;  // 26C
+		Location                                 origin;                        // 270
+		void*                                    collisionShape;                // 288
+		BSTArray<std::int32_t>                   collisions;                    // 290
 	};
 	static_assert(sizeof(ConeProjectile) == 0x280);
 }

--- a/include/RE/D/DebuggerMessages.h
+++ b/include/RE/D/DebuggerMessages.h
@@ -202,10 +202,10 @@ namespace RE::GameScript
 				kValue = 2,
 			};
 
-			REX::EnumSet<FormType, std::uint64_t> valuetype;        // 00
-			std::uint32_t                         threadId;         // 08
-			std::int32_t                          stackFrameIndex;  // 0C
-			RootType                              rootType;         // 10
+			REX::Enum<FormType, std::uint64_t> valueType;        // 00
+			std::uint32_t                      threadId;         // 08
+			std::int32_t                       stackFrameIndex;  // 0C
+			RootType                           rootType;         // 10
 		};
 		static_assert(sizeof(Root) == 0x18);
 

--- a/include/RE/D/DebuggerMessages.h
+++ b/include/RE/D/DebuggerMessages.h
@@ -195,17 +195,17 @@ namespace RE::GameScript
 
 		struct Root
 		{
-			enum class RootType
+			enum class RootType : std::uint8_t
 			{
 				kUnknown = 0,
 				kStackFrame = 1,
 				kValue = 2,
 			};
 
-			stl::enumeration<FormType, std::uint64_t> valuetype;        // 00
-			unsigned int                              threadId;         // 08
-			int                                       stackFrameIndex;  // 0C
-			stl::enumeration<RootType, std::uint8_t>  rootType;         // 10
+			REX::EnumSet<FormType, std::uint64_t> valuetype;        // 00
+			std::uint32_t                         threadId;         // 08
+			std::int32_t                          stackFrameIndex;  // 0C
+			RootType                              rootType;         // 10
 		};
 		static_assert(sizeof(Root) == 0x18);
 

--- a/include/RE/E/EffectSetting.h
+++ b/include/RE/E/EffectSetting.h
@@ -63,41 +63,41 @@ namespace RE
 			};
 
 			// members
-			TESForm*                                                       associatedForm;         // 00
-			ActorValueInfo*                                                associatedSkill;        // 08
-			BGSArtObject*                                                  castingArt;             // 10
-			BGSDualCastData*                                               dualCastData;           // 18
-			TESEffectShader*                                               effectShader;           // 20
-			TESEffectShader*                                               enchantShader;          // 28
-			BGSArtObject*                                                  enchantEffectArt;       // 30
-			SpellItem*                                                     equipAbility;           // 38
-			BGSExplosion*                                                  explosion;              // 40
-			BGSArtObject*                                                  hitEffectArt;           // 48
-			TESImageSpaceModifier*                                         imageSpaceMod;          // 50
-			BGSImpactDataSet*                                              impactDataSet;          // 58
-			TESObjectLIGH*                                                 light;                  // 60
-			BGSPerk*                                                       perk;                   // 68
-			ActorValueInfo*                                                primaryAV;              // 70
-			BGSProjectile*                                                 projectile;             // 78
-			ActorValueInfo*                                                resistVariable;         // 80
-			ActorValueInfo*                                                secondaryAV;            // 88
-			float                                                          baseCost;               // 90
-			float                                                          taperWeight;            // 94
-			std::uint32_t                                                  spellMakingArea;        // 98
-			float                                                          spellMakingChargeTime;  // 9C
-			float                                                          taperCurve;             // A0
-			float                                                          taperDuration;          // A4
-			float                                                          secondaryAVWeight;      // A8
-			float                                                          skillUsageMult;         // AC
-			float                                                          dualCastScale;          // B0
-			float                                                          unkB4;                  // B4
-			float                                                          unkB8;                  // B8
-			std::uint32_t                                                  minimumSkill;           // BC
-			stl::enumeration<Flag, std::uint32_t>                          flags;                  // C0
-			stl::enumeration<EffectArchetypes::ArchetypeID, std::uint32_t> archetype;              // C4
-			stl::enumeration<MagicSystem::CastingType, std::uint8_t>       castingType;            // C8
-			stl::enumeration<MagicSystem::Delivery, std::uint8_t>          deliveryType;           // C9
-			std::uint32_t                                                  unkCC;                  // CC
+			TESForm*                                                   associatedForm;         // 00
+			ActorValueInfo*                                            associatedSkill;        // 08
+			BGSArtObject*                                              castingArt;             // 10
+			BGSDualCastData*                                           dualCastData;           // 18
+			TESEffectShader*                                           effectShader;           // 20
+			TESEffectShader*                                           enchantShader;          // 28
+			BGSArtObject*                                              enchantEffectArt;       // 30
+			SpellItem*                                                 equipAbility;           // 38
+			BGSExplosion*                                              explosion;              // 40
+			BGSArtObject*                                              hitEffectArt;           // 48
+			TESImageSpaceModifier*                                     imageSpaceMod;          // 50
+			BGSImpactDataSet*                                          impactDataSet;          // 58
+			TESObjectLIGH*                                             light;                  // 60
+			BGSPerk*                                                   perk;                   // 68
+			ActorValueInfo*                                            primaryAV;              // 70
+			BGSProjectile*                                             projectile;             // 78
+			ActorValueInfo*                                            resistVariable;         // 80
+			ActorValueInfo*                                            secondaryAV;            // 88
+			float                                                      baseCost;               // 90
+			float                                                      taperWeight;            // 94
+			std::uint32_t                                              spellMakingArea;        // 98
+			float                                                      spellMakingChargeTime;  // 9C
+			float                                                      taperCurve;             // A0
+			float                                                      taperDuration;          // A4
+			float                                                      secondaryAVWeight;      // A8
+			float                                                      skillUsageMult;         // AC
+			float                                                      dualCastScale;          // B0
+			float                                                      unkB4;                  // B4
+			float                                                      unkB8;                  // B8
+			std::uint32_t                                              minimumSkill;           // BC
+			REX::EnumSet<Flag, std::uint32_t>                          flags;                  // C0
+			REX::EnumSet<EffectArchetypes::ArchetypeID, std::uint32_t> archetype;              // C4
+			REX::EnumSet<MagicSystem::CastingType, std::uint8_t>       castingType;            // C8
+			REX::EnumSet<MagicSystem::Delivery, std::uint8_t>          deliveryType;           // C9
+			std::uint32_t                                              unkCC;                  // CC
 		};
 		static_assert(sizeof(EffectSettingData) == 0xD0);
 

--- a/include/RE/E/EffectSetting.h
+++ b/include/RE/E/EffectSetting.h
@@ -63,41 +63,41 @@ namespace RE
 			};
 
 			// members
-			TESForm*                                                   associatedForm;         // 00
-			ActorValueInfo*                                            associatedSkill;        // 08
-			BGSArtObject*                                              castingArt;             // 10
-			BGSDualCastData*                                           dualCastData;           // 18
-			TESEffectShader*                                           effectShader;           // 20
-			TESEffectShader*                                           enchantShader;          // 28
-			BGSArtObject*                                              enchantEffectArt;       // 30
-			SpellItem*                                                 equipAbility;           // 38
-			BGSExplosion*                                              explosion;              // 40
-			BGSArtObject*                                              hitEffectArt;           // 48
-			TESImageSpaceModifier*                                     imageSpaceMod;          // 50
-			BGSImpactDataSet*                                          impactDataSet;          // 58
-			TESObjectLIGH*                                             light;                  // 60
-			BGSPerk*                                                   perk;                   // 68
-			ActorValueInfo*                                            primaryAV;              // 70
-			BGSProjectile*                                             projectile;             // 78
-			ActorValueInfo*                                            resistVariable;         // 80
-			ActorValueInfo*                                            secondaryAV;            // 88
-			float                                                      baseCost;               // 90
-			float                                                      taperWeight;            // 94
-			std::uint32_t                                              spellMakingArea;        // 98
-			float                                                      spellMakingChargeTime;  // 9C
-			float                                                      taperCurve;             // A0
-			float                                                      taperDuration;          // A4
-			float                                                      secondaryAVWeight;      // A8
-			float                                                      skillUsageMult;         // AC
-			float                                                      dualCastScale;          // B0
-			float                                                      unkB4;                  // B4
-			float                                                      unkB8;                  // B8
-			std::uint32_t                                              minimumSkill;           // BC
-			REX::EnumSet<Flag, std::uint32_t>                          flags;                  // C0
-			REX::EnumSet<EffectArchetypes::ArchetypeID, std::uint32_t> archetype;              // C4
-			REX::EnumSet<MagicSystem::CastingType, std::uint8_t>       castingType;            // C8
-			REX::EnumSet<MagicSystem::Delivery, std::uint8_t>          deliveryType;           // C9
-			std::uint32_t                                              unkCC;                  // CC
+			TESForm*                                                associatedForm;         // 00
+			ActorValueInfo*                                         associatedSkill;        // 08
+			BGSArtObject*                                           castingArt;             // 10
+			BGSDualCastData*                                        dualCastData;           // 18
+			TESEffectShader*                                        effectShader;           // 20
+			TESEffectShader*                                        enchantShader;          // 28
+			BGSArtObject*                                           enchantEffectArt;       // 30
+			SpellItem*                                              equipAbility;           // 38
+			BGSExplosion*                                           explosion;              // 40
+			BGSArtObject*                                           hitEffectArt;           // 48
+			TESImageSpaceModifier*                                  imageSpaceMod;          // 50
+			BGSImpactDataSet*                                       impactDataSet;          // 58
+			TESObjectLIGH*                                          light;                  // 60
+			BGSPerk*                                                perk;                   // 68
+			ActorValueInfo*                                         primaryAV;              // 70
+			BGSProjectile*                                          projectile;             // 78
+			ActorValueInfo*                                         resistVariable;         // 80
+			ActorValueInfo*                                         secondaryAV;            // 88
+			float                                                   baseCost;               // 90
+			float                                                   taperWeight;            // 94
+			std::uint32_t                                           spellMakingArea;        // 98
+			float                                                   spellMakingChargeTime;  // 9C
+			float                                                   taperCurve;             // A0
+			float                                                   taperDuration;          // A4
+			float                                                   secondaryAVWeight;      // A8
+			float                                                   skillUsageMult;         // AC
+			float                                                   dualCastScale;          // B0
+			float                                                   unkB4;                  // B4
+			float                                                   unkB8;                  // B8
+			std::uint32_t                                           minimumSkill;           // BC
+			REX::EnumSet<Flag, std::uint32_t>                       flags;                  // C0
+			REX::Enum<EffectArchetypes::ArchetypeID, std::uint32_t> archetype;              // C4
+			REX::Enum<MagicSystem::CastingType, std::uint8_t>       castingType;            // C8
+			REX::Enum<MagicSystem::Delivery, std::uint8_t>          deliveryType;           // C9
+			std::uint32_t                                           unkCC;                  // CC
 		};
 		static_assert(sizeof(EffectSettingData) == 0xD0);
 

--- a/include/RE/E/EnchantmentItem.h
+++ b/include/RE/E/EnchantmentItem.h
@@ -17,13 +17,13 @@ namespace RE
 		{
 		public:
 			// members
-			stl::enumeration<MagicSystem::CastingType, std::int32_t> castingType;       // 00
-			std::uint32_t                                            chargeOverride;    // 0C
-			stl::enumeration<MagicSystem::Delivery, std::uint8_t>    delivery;          // 10
-			stl::enumeration<MagicSystem::SpellType, std::uint8_t>   spellType;         // 11
-			float                                                    chargeTime;        // 14
-			EnchantmentItem*                                         baseEnchantment;   // 18
-			BGSListForm*                                             wornRestrictions;  // 20
+			REX::EnumSet<MagicSystem::CastingType, std::int32_t> castingType;       // 00
+			std::uint32_t                                        chargeOverride;    // 0C
+			REX::EnumSet<MagicSystem::Delivery, std::uint8_t>    delivery;          // 10
+			REX::EnumSet<MagicSystem::SpellType, std::uint8_t>   spellType;         // 11
+			float                                                chargeTime;        // 14
+			EnchantmentItem*                                     baseEnchantment;   // 18
+			BGSListForm*                                         wornRestrictions;  // 20
 		};
 		static_assert(sizeof(Data) == 0x28);
 

--- a/include/RE/E/EnchantmentItem.h
+++ b/include/RE/E/EnchantmentItem.h
@@ -17,13 +17,13 @@ namespace RE
 		{
 		public:
 			// members
-			REX::EnumSet<MagicSystem::CastingType, std::int32_t> castingType;       // 00
-			std::uint32_t                                        chargeOverride;    // 0C
-			REX::EnumSet<MagicSystem::Delivery, std::uint8_t>    delivery;          // 10
-			REX::EnumSet<MagicSystem::SpellType, std::uint8_t>   spellType;         // 11
-			float                                                chargeTime;        // 14
-			EnchantmentItem*                                     baseEnchantment;   // 18
-			BGSListForm*                                         wornRestrictions;  // 20
+			REX::Enum<MagicSystem::CastingType, std::int32_t> castingType;       // 00
+			std::uint32_t                                     chargeOverride;    // 0C
+			REX::Enum<MagicSystem::Delivery, std::uint8_t>    delivery;          // 10
+			REX::Enum<MagicSystem::SpellType, std::uint8_t>   spellType;         // 11
+			float                                             chargeTime;        // 14
+			EnchantmentItem*                                  baseEnchantment;   // 18
+			BGSListForm*                                      wornRestrictions;  // 20
 		};
 		static_assert(sizeof(Data) == 0x28);
 

--- a/include/RE/E/ExtraLock.h
+++ b/include/RE/E/ExtraLock.h
@@ -35,10 +35,10 @@ namespace RE
 		void                         SetLocked(bool a_locked);
 
 		// members
-		TESKey*                              key;        // 00
-		std::uint32_t                        numTries;   // 08
-		stl::enumeration<Flag, std::uint8_t> flags;      // 0C
-		std::int8_t                          baseLevel;  // 0D
+		TESKey*                          key;        // 00
+		std::uint32_t                    numTries;   // 08
+		REX::EnumSet<Flag, std::uint8_t> flags;      // 0C
+		std::int8_t                      baseLevel;  // 0D
 	};
 	static_assert(sizeof(REFR_LOCK) == 0x10);
 

--- a/include/RE/L/LockPickedEvent.h
+++ b/include/RE/L/LockPickedEvent.h
@@ -27,16 +27,16 @@ namespace RE
 		}
 
 		// members
-		NiPointer<TESObjectREFR>                actionRef;         // 00
-		NiPointer<TESObjectREFR>                lock;              // 08
-		BGSTerminalMenu*                        terminalMenu;      // 10
-		std::int32_t                            unk18;             // 14 - terminalMenu related
-		std::uint32_t                           numDigiPicksUsed;  // 18
-		float                                   unk20;             // 20 - 0.0f
-		float                                   unk24;             // 24 - 0.0f
-		REX::EnumSet<LOCK_LEVEL, std::uint32_t> lockLevel;         // 28
-		bool                                    succeeded;         // 2C
-		bool                                    isOffLimits;       // 2D
+		NiPointer<TESObjectREFR>             actionRef;         // 00
+		NiPointer<TESObjectREFR>             lock;              // 08
+		BGSTerminalMenu*                     terminalMenu;      // 10
+		std::int32_t                         unk18;             // 14 - terminalMenu related
+		std::uint32_t                        numDigiPicksUsed;  // 18
+		float                                unk20;             // 20 - 0.0f
+		float                                unk24;             // 24 - 0.0f
+		REX::Enum<LOCK_LEVEL, std::uint32_t> lockLevel;         // 28
+		bool                                 succeeded;         // 2C
+		bool                                 isOffLimits;       // 2D
 	};
 	static_assert(sizeof(LockPickedEvent) == 0x30);
 }

--- a/include/RE/L/LockPickedEvent.h
+++ b/include/RE/L/LockPickedEvent.h
@@ -27,16 +27,16 @@ namespace RE
 		}
 
 		// members
-		NiPointer<TESObjectREFR>                    actionRef;         // 00
-		NiPointer<TESObjectREFR>                    lock;              // 08
-		BGSTerminalMenu*                            terminalMenu;      // 10
-		std::int32_t                                unk18;             // 14 - terminalMenu related
-		std::uint32_t                               numDigiPicksUsed;  // 18
-		float                                       unk20;             // 20 - 0.0f
-		float                                       unk24;             // 24 - 0.0f
-		stl::enumeration<LOCK_LEVEL, std::uint32_t> lockLevel;         // 28
-		bool                                        succeeded;         // 2C
-		bool                                        isOffLimits;       // 2D
+		NiPointer<TESObjectREFR>                actionRef;         // 00
+		NiPointer<TESObjectREFR>                lock;              // 08
+		BGSTerminalMenu*                        terminalMenu;      // 10
+		std::int32_t                            unk18;             // 14 - terminalMenu related
+		std::uint32_t                           numDigiPicksUsed;  // 18
+		float                                   unk20;             // 20 - 0.0f
+		float                                   unk24;             // 24 - 0.0f
+		REX::EnumSet<LOCK_LEVEL, std::uint32_t> lockLevel;         // 28
+		bool                                    succeeded;         // 2C
+		bool                                    isOffLimits;       // 2D
 	};
 	static_assert(sizeof(LockPickedEvent) == 0x30);
 }

--- a/include/RE/M/MissileProjectile.h
+++ b/include/RE/M/MissileProjectile.h
@@ -16,16 +16,16 @@ namespace RE
 		virtual bool ShouldReorient() const;  // 15D
 
 		// members
-		NiMatrix3                                    unk260;                 // 260
-		NiPoint3                                     unk290;                 // 290
-		std::uint32_t                                unk29C;                 // 29C
-		NiPointer<bhkNPCollisionObject>              modelCollision;         // 2A0
-		stl::enumeration<ImpactResult, std::int32_t> impactResult;           // 2A8
-		bool                                         waitingToInitialize3D;  // 2AC
-		bool                                         unk2AD;                 // 2AD
-		bool                                         unk2AE;                 // 2AE
-		void*                                        unk2AF;
-		void*                                        unk2B7;
+		NiMatrix3                                unk260;                 // 260
+		NiPoint3                                 unk290;                 // 290
+		std::uint32_t                            unk29C;                 // 29C
+		NiPointer<bhkNPCollisionObject>          modelCollision;         // 2A0
+		REX::EnumSet<ImpactResult, std::int32_t> impactResult;           // 2A8
+		bool                                     waitingToInitialize3D;  // 2AC
+		bool                                     unk2AD;                 // 2AD
+		bool                                     unk2AE;                 // 2AE
+		void*                                    unk2AF;                 // 2AF
+		void*                                    unk2B7;                 // 2B7
 	};
 	static_assert(sizeof(MissileProjectile) == 0x2A0);
 }

--- a/include/RE/M/MissileProjectile.h
+++ b/include/RE/M/MissileProjectile.h
@@ -16,16 +16,16 @@ namespace RE
 		virtual bool ShouldReorient() const;  // 15D
 
 		// members
-		NiMatrix3                                unk260;                 // 260
-		NiPoint3                                 unk290;                 // 290
-		std::uint32_t                            unk29C;                 // 29C
-		NiPointer<bhkNPCollisionObject>          modelCollision;         // 2A0
-		REX::EnumSet<ImpactResult, std::int32_t> impactResult;           // 2A8
-		bool                                     waitingToInitialize3D;  // 2AC
-		bool                                     unk2AD;                 // 2AD
-		bool                                     unk2AE;                 // 2AE
-		void*                                    unk2AF;                 // 2AF
-		void*                                    unk2B7;                 // 2B7
+		NiMatrix3                             unk260;                 // 260
+		NiPoint3                              unk290;                 // 290
+		std::uint32_t                         unk29C;                 // 29C
+		NiPointer<bhkNPCollisionObject>       modelCollision;         // 2A0
+		REX::Enum<ImpactResult, std::int32_t> impactResult;           // 2A8
+		bool                                  waitingToInitialize3D;  // 2AC
+		bool                                  unk2AD;                 // 2AD
+		bool                                  unk2AE;                 // 2AE
+		void*                                 unk2AF;                 // 2AF
+		void*                                 unk2B7;                 // 2B7
 	};
 	static_assert(sizeof(MissileProjectile) == 0x2A0);
 }

--- a/include/RE/P/Projectile.h
+++ b/include/RE/P/Projectile.h
@@ -33,55 +33,55 @@ namespace RE
 	{
 	public:
 		// members
-		Location                                               origin;                   // 00
-		NiPoint3                                               contactNormal;            // 18
-		NiPoint3                                               destination;              // 24
-		BGSProjectile*                                         projectileBase;           // 30
-		TESObjectREFR*                                         shooter;                  // 38
-		CombatController*                                      shooterCombatController;  // 40
-		TESAmmo*                                               fromAmmo;                 // 48
-		TESObjectREFR*                                         homingTarget;             // 50
-		TESObjectCELL*                                         parentCell;               // 58
-		MagicItem*                                             spell;                    // 60
-		AlchemyItem*                                           poison;                   // 68
-		BGSObjectInstanceT<TESObjectWEAP>                      fromWeapon;               // 70
-		REX::EnumSet<MagicSystem::CastingSource, std::uint8_t> castingSource;            // 80
-		REX::EnumSet<BGSBodyPartDefs::LIMB_ENUM, std::int32_t> targetLimbEnum;           // 84
-		void*                                                  unk88;                    // 88 - smart ptr
-		BGSEquipIndex                                          equipIndex;               // 90
-		std::uint32_t                                          unk94;                    // 94
-		Location                                               unk98;                    // 98
-		float                                                  unkB0;                    // B0
-		std::uint32_t                                          unkB4;                    // B4
-		std::uint32_t                                          unkB8;                    // B8
-		std::uint32_t                                          unkBC;                    // BC
-		std::uint32_t                                          unkC0;                    // C0
-		float                                                  power;                    // C4
-		float                                                  unkC8;                    // C8
-		float                                                  unkCC;                    // CC
-		std::uint32_t                                          unkD0;                    // D0
-		float                                                  unkD4;                    // D4
-		float                                                  range;                    // D8
-		float                                                  unkDC;                    // DC
-		std::uint8_t                                           unkE0;                    // E0
-		std::uint8_t                                           unkE1;                    // E1
-		std::uint8_t                                           unkE2;                    // E2
-		std::uint8_t                                           unkE3;                    // E3
-		bool                                                   useOrigin;                // E4
-		std::uint8_t                                           unkE5;                    // E5
-		std::uint8_t                                           unkE6;                    // E6
-		std::uint8_t                                           unkE7;                    // E7
-		std::uint8_t                                           unkE8;                    // E8
-		std::uint8_t                                           unkE9;                    // E9
-		bool                                                   penetrates;               // EA
-		std::uint8_t                                           unkEB;                    // EB
-		std::uint8_t                                           unkEC;                    // EC
-		std::uint8_t                                           unkED;                    // ED
-		std::uint8_t                                           unkEE;                    // EE
-		std::uint8_t                                           unkEF;                    // EF
-		std::uint8_t                                           unkF0;                    // F0
-		std::uint8_t                                           unkF1;                    // F1
-		bool                                                   continuousUpdate;         // F2
+		Location                                            origin;                   // 00
+		NiPoint3                                            contactNormal;            // 18
+		NiPoint3                                            destination;              // 24
+		BGSProjectile*                                      projectileBase;           // 30
+		TESObjectREFR*                                      shooter;                  // 38
+		CombatController*                                   shooterCombatController;  // 40
+		TESAmmo*                                            fromAmmo;                 // 48
+		TESObjectREFR*                                      homingTarget;             // 50
+		TESObjectCELL*                                      parentCell;               // 58
+		MagicItem*                                          spell;                    // 60
+		AlchemyItem*                                        poison;                   // 68
+		BGSObjectInstanceT<TESObjectWEAP>                   fromWeapon;               // 70
+		REX::Enum<MagicSystem::CastingSource, std::uint8_t> castingSource;            // 80
+		REX::Enum<BGSBodyPartDefs::LIMB_ENUM, std::int32_t> targetLimbEnum;           // 84
+		void*                                               unk88;                    // 88 - smart ptr
+		BGSEquipIndex                                       equipIndex;               // 90
+		std::uint32_t                                       unk94;                    // 94
+		Location                                            unk98;                    // 98
+		float                                               unkB0;                    // B0
+		std::uint32_t                                       unkB4;                    // B4
+		std::uint32_t                                       unkB8;                    // B8
+		std::uint32_t                                       unkBC;                    // BC
+		std::uint32_t                                       unkC0;                    // C0
+		float                                               power;                    // C4
+		float                                               unkC8;                    // C8
+		float                                               unkCC;                    // CC
+		std::uint32_t                                       unkD0;                    // D0
+		float                                               unkD4;                    // D4
+		float                                               range;                    // D8
+		float                                               unkDC;                    // DC
+		std::uint8_t                                        unkE0;                    // E0
+		std::uint8_t                                        unkE1;                    // E1
+		std::uint8_t                                        unkE2;                    // E2
+		std::uint8_t                                        unkE3;                    // E3
+		bool                                                useOrigin;                // E4
+		std::uint8_t                                        unkE5;                    // E5
+		std::uint8_t                                        unkE6;                    // E6
+		std::uint8_t                                        unkE7;                    // E7
+		std::uint8_t                                        unkE8;                    // E8
+		std::uint8_t                                        unkE9;                    // E9
+		bool                                                penetrates;               // EA
+		std::uint8_t                                        unkEB;                    // EB
+		std::uint8_t                                        unkEC;                    // EC
+		std::uint8_t                                        unkED;                    // ED
+		std::uint8_t                                        unkEE;                    // EE
+		std::uint8_t                                        unkEF;                    // EF
+		std::uint8_t                                        unkF0;                    // F0
+		std::uint8_t                                        unkF1;                    // F1
+		bool                                                continuousUpdate;         // F2
 	};
 	static_assert(sizeof(ProjectileLaunchData) == 0xF8);
 
@@ -94,28 +94,28 @@ namespace RE
 		{
 		public:
 			// members
-			Location                                               location;                // 00
-			NiPoint3                                               normal;                  // 18
-			std::uint64_t                                          unk28;                   // 28
-			std::uint32_t                                          collidee;                // 30 - TESPointerHandle
-			std::uint32_t                                          unk34;                   // 34
-			NiPointer<bhkNPCollisionObject>                        colObj;                  // 38
-			BGSMaterialType*                                       materialType;            // 40
-			REX::EnumSet<BGSBodyPartDefs::LIMB_ENUM, std::int32_t> damageLimb;              // 48
-			REX::EnumSet<COL_LAYER, std::int32_t>                  collisionLayer;          // 4C
-			std::uint64_t                                          unk50;                   // 50
-			REX::EnumSet<ImpactResult, std::int32_t>               resultOverride;          // 58
-			std::uint32_t                                          unk5C;                   // 5C
-			float                                                  decalSize;               // 60
-			std::uint32_t                                          collisionShapeKey;       // 64
-			std::int16_t                                           targetWorldObjectCount;  // 68
-			std::int16_t                                           targetWorldObjectIndex;  // 6A
-			bool                                                   processed;               // 6C
-			bool                                                   spellCast;               // 6D
-			bool                                                   effectSpawned;           // 6E
-			bool                                                   backFace;                // 6F
-			std::uint8_t                                           unk70;                   // 70
-			std::uint64_t                                          unk78;                   // 78
+			Location                                            location;                // 00
+			NiPoint3                                            normal;                  // 18
+			std::uint64_t                                       unk28;                   // 28
+			std::uint32_t                                       collidee;                // 30 - TESPointerHandle
+			std::uint32_t                                       unk34;                   // 34
+			NiPointer<bhkNPCollisionObject>                     colObj;                  // 38
+			BGSMaterialType*                                    materialType;            // 40
+			REX::Enum<BGSBodyPartDefs::LIMB_ENUM, std::int32_t> damageLimb;              // 48
+			REX::Enum<COL_LAYER, std::int32_t>                  collisionLayer;          // 4C
+			std::uint64_t                                       unk50;                   // 50
+			REX::Enum<ImpactResult, std::int32_t>               resultOverride;          // 58
+			std::uint32_t                                       unk5C;                   // 5C
+			float                                               decalSize;               // 60
+			std::uint32_t                                       collisionShapeKey;       // 64
+			std::int16_t                                        targetWorldObjectCount;  // 68
+			std::int16_t                                        targetWorldObjectIndex;  // 6A
+			bool                                                processed;               // 6C
+			bool                                                spellCast;               // 6D
+			bool                                                effectSpawned;           // 6E
+			bool                                                backFace;                // 6F
+			std::uint8_t                                        unk70;                   // 70
+			std::uint64_t                                       unk78;                   // 78
 		};
 		static_assert(sizeof(ImpactData) == 0x80);
 
@@ -169,59 +169,59 @@ namespace RE
 		virtual bool          ShouldUseDesiredTarget();                      // 15C
 
 		// members
-		BSTArray<ImpactData>                                   impacts;              // 0F0
-		NiPointer<bhkNPCollisionObject>                        collisionObject;      // 100
-		NiPointer<TESObjectREFR>                               droppedRefr;          // 108
-		NiTransform                                            followOffset;         // 110
-		BSSpinLock                                             lock;                 // 150
-		NiPoint3                                               movementDirection;    // 158
-		NiPoint3                                               velocity;             // 164
-		void*                                                  unk170;               // 170 - smart ptr
-		NiPointer<ActorCause>                                  actorCause;           // 178
-		std::uint32_t                                          shooterHandle;        // 180 - TESPointerHandle
-		std::uint32_t                                          desiredTargetHandle;  // 184 - TESPointerHandle
-		std::uint32_t                                          unk188;               // 188
-		std::uint32_t                                          unk18C;               // 18C
-		std::uint32_t                                          unk190;               // 190
-		std::uint32_t                                          unk194;               // 194
-		BGSExplosion*                                          explosion;            // 198
-		MagicItem*                                             spell;                // 1A0
-		EffectSetting*                                         avEffect;             // 1A8
-		void*                                                  unk1B0;               // 1B0 - smart ptr
-		void*                                                  unk1B8;               // 1B8 - smart ptr
-		void*                                                  unk1C0;               // 1C0 - smart ptr
-		void*                                                  unk1C8;               // 1C8 - smart ptr
-		std::uint64_t                                          unk1D0;               // 1D0
-		BGSEquipIndex                                          equipIndex;           // 1D8
-		REX::EnumSet<BGSBodyPartDefs::LIMB_ENUM, std::int32_t> targetLimbEnum;       // 1DC
-		NiPointer<NiAVObject>                                  targetLimbObj;        // 1E0
-		std::uint64_t                                          unk1E8;               // 1E8
-		BGSObjectInstanceT<TESObjectWEAP>                      weaponSource;         // 1F0
-		TESAmmo*                                               ammoSource;           // 200
-		std::uint64_t                                          flags;                // 208
-		std::uint32_t                                          unk210;               // 210
-		float                                                  power;                // 214
-		float                                                  speedMult;            // 218
-		float                                                  range;                // 21C
-		float                                                  age;                  // 220
-		float                                                  damage;               // 224
-		float                                                  alpha;                // 228
-		float                                                  explosionTimer;       // 22C
-		float                                                  blinkTimer;           // 230
-		float                                                  distanceMoved;        // 234
-		std::uint32_t                                          unk238;               // 238
-		float                                                  scale;                // 23C
-		float                                                  unk240;               // 240
-		float                                                  unk244;               // 244
-		std::uint32_t                                          unk248;               // 248
-		std::uint32_t                                          unk24C;               // 24C
-		std::uint32_t                                          unk250;               // 250
-		std::uint32_t                                          unk254;               // 254
-		REX::EnumSet<MagicSystem::CastingSource, std::uint8_t> castingSource;        // 258
-		std::uint8_t                                           unk259;               // 259
-		bool                                                   artRequested;         // 25A
-		bool                                                   animationsLoaded;     // 25B
-		std::uint8_t                                           unk25C;               // 25C
+		BSTArray<ImpactData>                                impacts;              // 0F0
+		NiPointer<bhkNPCollisionObject>                     collisionObject;      // 100
+		NiPointer<TESObjectREFR>                            droppedRefr;          // 108
+		NiTransform                                         followOffset;         // 110
+		BSSpinLock                                          lock;                 // 150
+		NiPoint3                                            movementDirection;    // 158
+		NiPoint3                                            velocity;             // 164
+		void*                                               unk170;               // 170 - smart ptr
+		NiPointer<ActorCause>                               actorCause;           // 178
+		std::uint32_t                                       shooterHandle;        // 180 - TESPointerHandle
+		std::uint32_t                                       desiredTargetHandle;  // 184 - TESPointerHandle
+		std::uint32_t                                       unk188;               // 188
+		std::uint32_t                                       unk18C;               // 18C
+		std::uint32_t                                       unk190;               // 190
+		std::uint32_t                                       unk194;               // 194
+		BGSExplosion*                                       explosion;            // 198
+		MagicItem*                                          spell;                // 1A0
+		EffectSetting*                                      avEffect;             // 1A8
+		void*                                               unk1B0;               // 1B0 - smart ptr
+		void*                                               unk1B8;               // 1B8 - smart ptr
+		void*                                               unk1C0;               // 1C0 - smart ptr
+		void*                                               unk1C8;               // 1C8 - smart ptr
+		std::uint64_t                                       unk1D0;               // 1D0
+		BGSEquipIndex                                       equipIndex;           // 1D8
+		REX::Enum<BGSBodyPartDefs::LIMB_ENUM, std::int32_t> targetLimbEnum;       // 1DC
+		NiPointer<NiAVObject>                               targetLimbObj;        // 1E0
+		std::uint64_t                                       unk1E8;               // 1E8
+		BGSObjectInstanceT<TESObjectWEAP>                   weaponSource;         // 1F0
+		TESAmmo*                                            ammoSource;           // 200
+		std::uint64_t                                       flags;                // 208
+		std::uint32_t                                       unk210;               // 210
+		float                                               power;                // 214
+		float                                               speedMult;            // 218
+		float                                               range;                // 21C
+		float                                               age;                  // 220
+		float                                               damage;               // 224
+		float                                               alpha;                // 228
+		float                                               explosionTimer;       // 22C
+		float                                               blinkTimer;           // 230
+		float                                               distanceMoved;        // 234
+		std::uint32_t                                       unk238;               // 238
+		float                                               scale;                // 23C
+		float                                               unk240;               // 240
+		float                                               unk244;               // 244
+		std::uint32_t                                       unk248;               // 248
+		std::uint32_t                                       unk24C;               // 24C
+		std::uint32_t                                       unk250;               // 250
+		std::uint32_t                                       unk254;               // 254
+		REX::Enum<MagicSystem::CastingSource, std::uint8_t> castingSource;        // 258
+		std::uint8_t                                        unk259;               // 259
+		bool                                                artRequested;         // 25A
+		bool                                                animationsLoaded;     // 25B
+		std::uint8_t                                        unk25C;               // 25C
 	};
 	static_assert(sizeof(Projectile) == 0x240);
 }

--- a/include/RE/P/Projectile.h
+++ b/include/RE/P/Projectile.h
@@ -33,55 +33,55 @@ namespace RE
 	{
 	public:
 		// members
-		Location                                                   origin;                   // 00
-		NiPoint3                                                   contactNormal;            // 18
-		NiPoint3                                                   destination;              // 24
-		BGSProjectile*                                             projectileBase;           // 30
-		TESObjectREFR*                                             shooter;                  // 38
-		CombatController*                                          shooterCombatController;  // 40
-		TESAmmo*                                                   fromAmmo;                 // 48
-		TESObjectREFR*                                             homingTarget;             // 50
-		TESObjectCELL*                                             parentCell;               // 58
-		MagicItem*                                                 spell;                    // 60
-		AlchemyItem*                                               poison;                   // 68
-		BGSObjectInstanceT<TESObjectWEAP>                          fromWeapon;               // 70
-		stl::enumeration<MagicSystem::CastingSource, std::uint8_t> castingSource;            // 80
-		stl::enumeration<BGSBodyPartDefs::LIMB_ENUM, std::int32_t> targetLimbEnum;           // 84
-		void*                                                      unk88;                    // 88 - smart ptr
-		BGSEquipIndex                                              equipIndex;               // 90
-		std::uint32_t                                              unk94;                    // 94
-		Location                                                   unk98;                    // 98
-		float                                                      unkB0;                    // B0
-		std::uint32_t                                              unkB4;                    // B4
-		std::uint32_t                                              unkB8;                    // B8
-		std::uint32_t                                              unkBC;                    // BC
-		std::uint32_t                                              unkC0;                    // C0
-		float                                                      power;                    // C4
-		float                                                      unkC8;                    // C8
-		float                                                      unkCC;                    // CC
-		std::uint32_t                                              unkD0;                    // D0
-		float                                                      unkD4;                    // D4
-		float                                                      range;                    // D8
-		float                                                      unkDC;                    // DC
-		std::uint8_t                                               unkE0;                    // E0
-		std::uint8_t                                               unkE1;                    // E1
-		std::uint8_t                                               unkE2;                    // E2
-		std::uint8_t                                               unkE3;                    // E3
-		bool                                                       useOrigin;                // E4
-		std::uint8_t                                               unkE5;                    // E5
-		std::uint8_t                                               unkE6;                    // E6
-		std::uint8_t                                               unkE7;                    // E7
-		std::uint8_t                                               unkE8;                    // E8
-		std::uint8_t                                               unkE9;                    // E9
-		bool                                                       penetrates;               // EA
-		std::uint8_t                                               unkEB;                    // EB
-		std::uint8_t                                               unkEC;                    // EC
-		std::uint8_t                                               unkED;                    // ED
-		std::uint8_t                                               unkEE;                    // EE
-		std::uint8_t                                               unkEF;                    // EF
-		std::uint8_t                                               unkF0;                    // F0
-		std::uint8_t                                               unkF1;                    // F1
-		bool                                                       continuousUpdate;         // F2
+		Location                                               origin;                   // 00
+		NiPoint3                                               contactNormal;            // 18
+		NiPoint3                                               destination;              // 24
+		BGSProjectile*                                         projectileBase;           // 30
+		TESObjectREFR*                                         shooter;                  // 38
+		CombatController*                                      shooterCombatController;  // 40
+		TESAmmo*                                               fromAmmo;                 // 48
+		TESObjectREFR*                                         homingTarget;             // 50
+		TESObjectCELL*                                         parentCell;               // 58
+		MagicItem*                                             spell;                    // 60
+		AlchemyItem*                                           poison;                   // 68
+		BGSObjectInstanceT<TESObjectWEAP>                      fromWeapon;               // 70
+		REX::EnumSet<MagicSystem::CastingSource, std::uint8_t> castingSource;            // 80
+		REX::EnumSet<BGSBodyPartDefs::LIMB_ENUM, std::int32_t> targetLimbEnum;           // 84
+		void*                                                  unk88;                    // 88 - smart ptr
+		BGSEquipIndex                                          equipIndex;               // 90
+		std::uint32_t                                          unk94;                    // 94
+		Location                                               unk98;                    // 98
+		float                                                  unkB0;                    // B0
+		std::uint32_t                                          unkB4;                    // B4
+		std::uint32_t                                          unkB8;                    // B8
+		std::uint32_t                                          unkBC;                    // BC
+		std::uint32_t                                          unkC0;                    // C0
+		float                                                  power;                    // C4
+		float                                                  unkC8;                    // C8
+		float                                                  unkCC;                    // CC
+		std::uint32_t                                          unkD0;                    // D0
+		float                                                  unkD4;                    // D4
+		float                                                  range;                    // D8
+		float                                                  unkDC;                    // DC
+		std::uint8_t                                           unkE0;                    // E0
+		std::uint8_t                                           unkE1;                    // E1
+		std::uint8_t                                           unkE2;                    // E2
+		std::uint8_t                                           unkE3;                    // E3
+		bool                                                   useOrigin;                // E4
+		std::uint8_t                                           unkE5;                    // E5
+		std::uint8_t                                           unkE6;                    // E6
+		std::uint8_t                                           unkE7;                    // E7
+		std::uint8_t                                           unkE8;                    // E8
+		std::uint8_t                                           unkE9;                    // E9
+		bool                                                   penetrates;               // EA
+		std::uint8_t                                           unkEB;                    // EB
+		std::uint8_t                                           unkEC;                    // EC
+		std::uint8_t                                           unkED;                    // ED
+		std::uint8_t                                           unkEE;                    // EE
+		std::uint8_t                                           unkEF;                    // EF
+		std::uint8_t                                           unkF0;                    // F0
+		std::uint8_t                                           unkF1;                    // F1
+		bool                                                   continuousUpdate;         // F2
 	};
 	static_assert(sizeof(ProjectileLaunchData) == 0xF8);
 
@@ -94,28 +94,28 @@ namespace RE
 		{
 		public:
 			// members
-			Location                                                   location;                // 00
-			NiPoint3                                                   normal;                  // 18
-			std::uint64_t                                              unk28;                   // 28
-			std::uint32_t                                              collidee;                // 30 - TESPointerHandle
-			std::uint32_t                                              unk34;                   // 34
-			NiPointer<bhkNPCollisionObject>                            colObj;                  // 38
-			BGSMaterialType*                                           materialType;            // 40
-			stl::enumeration<BGSBodyPartDefs::LIMB_ENUM, std::int32_t> damageLimb;              // 48
-			stl::enumeration<COL_LAYER, std::int32_t>                  collisionLayer;          // 4C
-			std::uint64_t                                              unk50;                   // 50
-			stl::enumeration<ImpactResult, std::int32_t>               resultOverride;          // 58
-			std::uint32_t                                              unk5C;                   // 5C
-			float                                                      decalSize;               // 60
-			std::uint32_t                                              collisionShapeKey;       // 64
-			std::int16_t                                               targetWorldObjectCount;  // 68
-			std::int16_t                                               targetWorldObjectIndex;  // 6A
-			bool                                                       processed;               // 6C
-			bool                                                       spellCast;               // 6D
-			bool                                                       effectSpawned;           // 6E
-			bool                                                       backFace;                // 6F
-			std::uint8_t                                               unk70;                   // 70
-			std::uint64_t                                              unk78;                   // 78
+			Location                                               location;                // 00
+			NiPoint3                                               normal;                  // 18
+			std::uint64_t                                          unk28;                   // 28
+			std::uint32_t                                          collidee;                // 30 - TESPointerHandle
+			std::uint32_t                                          unk34;                   // 34
+			NiPointer<bhkNPCollisionObject>                        colObj;                  // 38
+			BGSMaterialType*                                       materialType;            // 40
+			REX::EnumSet<BGSBodyPartDefs::LIMB_ENUM, std::int32_t> damageLimb;              // 48
+			REX::EnumSet<COL_LAYER, std::int32_t>                  collisionLayer;          // 4C
+			std::uint64_t                                          unk50;                   // 50
+			REX::EnumSet<ImpactResult, std::int32_t>               resultOverride;          // 58
+			std::uint32_t                                          unk5C;                   // 5C
+			float                                                  decalSize;               // 60
+			std::uint32_t                                          collisionShapeKey;       // 64
+			std::int16_t                                           targetWorldObjectCount;  // 68
+			std::int16_t                                           targetWorldObjectIndex;  // 6A
+			bool                                                   processed;               // 6C
+			bool                                                   spellCast;               // 6D
+			bool                                                   effectSpawned;           // 6E
+			bool                                                   backFace;                // 6F
+			std::uint8_t                                           unk70;                   // 70
+			std::uint64_t                                          unk78;                   // 78
 		};
 		static_assert(sizeof(ImpactData) == 0x80);
 
@@ -169,59 +169,59 @@ namespace RE
 		virtual bool          ShouldUseDesiredTarget();                      // 15C
 
 		// members
-		BSTArray<ImpactData>                                       impacts;              // 0F0
-		NiPointer<bhkNPCollisionObject>                            collisionObject;      // 100
-		NiPointer<TESObjectREFR>                                   droppedRefr;          // 108
-		NiTransform                                                followOffset;         // 110
-		BSSpinLock                                                 lock;                 // 150
-		NiPoint3                                                   movementDirection;    // 158
-		NiPoint3                                                   velocity;             // 164
-		void*                                                      unk170;               // 170 - smart ptr
-		NiPointer<ActorCause>                                      actorCause;           // 178
-		std::uint32_t                                              shooterHandle;        // 180 - TESPointerHandle
-		std::uint32_t                                              desiredTargetHandle;  // 184 - TESPointerHandle
-		std::uint32_t                                              unk188;               // 188
-		std::uint32_t                                              unk18C;               // 18C
-		std::uint32_t                                              unk190;               // 190
-		std::uint32_t                                              unk194;               // 194
-		BGSExplosion*                                              explosion;            // 198
-		MagicItem*                                                 spell;                // 1A0
-		EffectSetting*                                             avEffect;             // 1A8
-		void*                                                      unk1B0;               // 1B0 - smart ptr
-		void*                                                      unk1B8;               // 1B8 - smart ptr
-		void*                                                      unk1C0;               // 1C0 - smart ptr
-		void*                                                      unk1C8;               // 1C8 - smart ptr
-		std::uint64_t                                              unk1D0;               // 1D0
-		BGSEquipIndex                                              equipIndex;           // 1D8
-		stl::enumeration<BGSBodyPartDefs::LIMB_ENUM, std::int32_t> targetLimbEnum;       // 1DC
-		NiPointer<NiAVObject>                                      targetLimbObj;        // 1E0
-		std::uint64_t                                              unk1E8;               // 1E8
-		BGSObjectInstanceT<TESObjectWEAP>                          weaponSource;         // 1F0
-		TESAmmo*                                                   ammoSource;           // 200
-		std::uint64_t                                              flags;                // 208
-		std::uint32_t                                              unk210;               // 210
-		float                                                      power;                // 214
-		float                                                      speedMult;            // 218
-		float                                                      range;                // 21C
-		float                                                      age;                  // 220
-		float                                                      damage;               // 224
-		float                                                      alpha;                // 228
-		float                                                      explosionTimer;       // 22C
-		float                                                      blinkTimer;           // 230
-		float                                                      distanceMoved;        // 234
-		std::uint32_t                                              unk238;               // 238
-		float                                                      scale;                // 23C
-		float                                                      unk240;               // 240
-		float                                                      unk244;               // 244
-		std::uint32_t                                              unk248;               // 248
-		std::uint32_t                                              unk24C;               // 24C
-		std::uint32_t                                              unk250;               // 250
-		std::uint32_t                                              unk254;               // 254
-		stl::enumeration<MagicSystem::CastingSource, std::uint8_t> castingSource;        // 258
-		std::uint8_t                                               unk259;               // 259
-		bool                                                       artRequested;         // 25A
-		bool                                                       animationsLoaded;     // 25B
-		std::uint8_t                                               unk25C;               // 25C
+		BSTArray<ImpactData>                                   impacts;              // 0F0
+		NiPointer<bhkNPCollisionObject>                        collisionObject;      // 100
+		NiPointer<TESObjectREFR>                               droppedRefr;          // 108
+		NiTransform                                            followOffset;         // 110
+		BSSpinLock                                             lock;                 // 150
+		NiPoint3                                               movementDirection;    // 158
+		NiPoint3                                               velocity;             // 164
+		void*                                                  unk170;               // 170 - smart ptr
+		NiPointer<ActorCause>                                  actorCause;           // 178
+		std::uint32_t                                          shooterHandle;        // 180 - TESPointerHandle
+		std::uint32_t                                          desiredTargetHandle;  // 184 - TESPointerHandle
+		std::uint32_t                                          unk188;               // 188
+		std::uint32_t                                          unk18C;               // 18C
+		std::uint32_t                                          unk190;               // 190
+		std::uint32_t                                          unk194;               // 194
+		BGSExplosion*                                          explosion;            // 198
+		MagicItem*                                             spell;                // 1A0
+		EffectSetting*                                         avEffect;             // 1A8
+		void*                                                  unk1B0;               // 1B0 - smart ptr
+		void*                                                  unk1B8;               // 1B8 - smart ptr
+		void*                                                  unk1C0;               // 1C0 - smart ptr
+		void*                                                  unk1C8;               // 1C8 - smart ptr
+		std::uint64_t                                          unk1D0;               // 1D0
+		BGSEquipIndex                                          equipIndex;           // 1D8
+		REX::EnumSet<BGSBodyPartDefs::LIMB_ENUM, std::int32_t> targetLimbEnum;       // 1DC
+		NiPointer<NiAVObject>                                  targetLimbObj;        // 1E0
+		std::uint64_t                                          unk1E8;               // 1E8
+		BGSObjectInstanceT<TESObjectWEAP>                      weaponSource;         // 1F0
+		TESAmmo*                                               ammoSource;           // 200
+		std::uint64_t                                          flags;                // 208
+		std::uint32_t                                          unk210;               // 210
+		float                                                  power;                // 214
+		float                                                  speedMult;            // 218
+		float                                                  range;                // 21C
+		float                                                  age;                  // 220
+		float                                                  damage;               // 224
+		float                                                  alpha;                // 228
+		float                                                  explosionTimer;       // 22C
+		float                                                  blinkTimer;           // 230
+		float                                                  distanceMoved;        // 234
+		std::uint32_t                                          unk238;               // 238
+		float                                                  scale;                // 23C
+		float                                                  unk240;               // 240
+		float                                                  unk244;               // 244
+		std::uint32_t                                          unk248;               // 248
+		std::uint32_t                                          unk24C;               // 24C
+		std::uint32_t                                          unk250;               // 250
+		std::uint32_t                                          unk254;               // 254
+		REX::EnumSet<MagicSystem::CastingSource, std::uint8_t> castingSource;        // 258
+		std::uint8_t                                           unk259;               // 259
+		bool                                                   artRequested;         // 25A
+		bool                                                   animationsLoaded;     // 25B
+		std::uint8_t                                           unk25C;               // 25C
 	};
 	static_assert(sizeof(Projectile) == 0x240);
 }

--- a/include/RE/P/PropertyTypeInfo.h
+++ b/include/RE/P/PropertyTypeInfo.h
@@ -17,16 +17,16 @@ namespace RE::BSScript
 		};
 
 		// members
-		BSFixedString                                parentObjName;  // 00
-		BSFixedString                                propertyName;   // 08
-		TypeInfo                                     type;           // 10
-		stl::enumeration<Permissions, std::uint32_t> permissions;    // 18
-		std::uint32_t                                pad1C;          // 1C
-		BSTSmartPointer<IFunction>                   getFunction;    // 20
-		BSTSmartPointer<IFunction>                   setFunction;    // 28
-		std::uint32_t                                autoVarIndex;   // 30
-		std::uint32_t                                userFlags;      // 34
-		BSFixedString                                docString;      // 38
+		BSFixedString                            parentObjName;  // 00
+		BSFixedString                            propertyName;   // 08
+		TypeInfo                                 type;           // 10
+		REX::EnumSet<Permissions, std::uint32_t> permissions;    // 18
+		std::uint32_t                            pad1C;          // 1C
+		BSTSmartPointer<IFunction>               getFunction;    // 20
+		BSTSmartPointer<IFunction>               setFunction;    // 28
+		std::uint32_t                            autoVarIndex;   // 30
+		std::uint32_t                            userFlags;      // 34
+		BSFixedString                            docString;      // 38
 	};
 	static_assert(sizeof(PropertyTypeInfo) == 0x40);
 }

--- a/include/RE/R/ReadableStringTable.h
+++ b/include/RE/R/ReadableStringTable.h
@@ -37,7 +37,7 @@ namespace RE::BSScript::Internal
 		// members
 		msvc::unique_ptr<BSTObjectArena<StringTableScrapPage, BSTObjectArenaScrapAlloc, 1>> scrapPages;  // 00
 		msvc::unique_ptr<BSScrapArray<StringEntry>>                                         entries;     // 08
-		stl::enumeration<StringIndexSize, std::int32_t>                                     indexSize;   // 10
+		REX::EnumSet<StringIndexSize, std::int32_t>                                         indexSize;   // 10
 	};
 	static_assert(sizeof(ReadableStringTable) == 0x18);
 }

--- a/include/RE/R/ReadableStringTable.h
+++ b/include/RE/R/ReadableStringTable.h
@@ -37,7 +37,7 @@ namespace RE::BSScript::Internal
 		// members
 		msvc::unique_ptr<BSTObjectArena<StringTableScrapPage, BSTObjectArenaScrapAlloc, 1>> scrapPages;  // 00
 		msvc::unique_ptr<BSScrapArray<StringEntry>>                                         entries;     // 08
-		REX::EnumSet<StringIndexSize, std::int32_t>                                         indexSize;   // 10
+		REX::Enum<StringIndexSize, std::int32_t>                                            indexSize;   // 10
 	};
 	static_assert(sizeof(ReadableStringTable) == 0x18);
 }

--- a/include/RE/RTTI.h
+++ b/include/RE/RTTI.h
@@ -77,7 +77,7 @@ namespace RE
 			RVA<TypeDescriptor>                        typeDescriptor;     // 00
 			std::uint32_t                              numContainedBases;  // 04
 			PMD                                        pmd;                // 08
-			stl::enumeration<Attribute, std::uint32_t> attributes;         // 14
+			REX::EnumSet<Attribute, std::uint32_t>     attributes;         // 14
 		};
 
 		static_assert(sizeof(BaseClassDescriptor) == 0x18);
@@ -95,7 +95,7 @@ namespace RE
 
 			// members
 			std::uint32_t                              signature;       // 00
-			stl::enumeration<Attribute, std::uint32_t> attributes;      // 04
+			REX::EnumSet<Attribute, std::uint32_t>     attributes;      // 04
 			std::uint32_t                              numBaseClasses;  // 08
 			RVA<BaseClassDescriptor>                   baseClassArray;  // 0C
 		};
@@ -105,18 +105,18 @@ namespace RE
 		struct CompleteObjectLocator
 		{
 		public:
-			enum class Signature
+			enum class Signature : std::uint32_t
 			{
 				x86 = 0,
 				x64 = 1
 			};
 
 			// members
-			stl::enumeration<Signature, std::uint32_t> signature;        // 00
-			std::uint32_t                              offset;           // 04
-			std::uint32_t                              ctorDispOffset;   // 08
-			RVA<TypeDescriptor>                        typeDescriptor;   // 0C
-			RVA<ClassHierarchyDescriptor>              classDescriptor;  // 10
+			Signature                     signature;        // 00
+			std::uint32_t                 offset;           // 04
+			std::uint32_t                 ctorDispOffset;   // 08
+			RVA<TypeDescriptor>           typeDescriptor;   // 0C
+			RVA<ClassHierarchyDescriptor> classDescriptor;  // 10
 		};
 
 		static_assert(sizeof(CompleteObjectLocator) == 0x14);

--- a/include/RE/S/ScaleformGFxState.h
+++ b/include/RE/S/ScaleformGFxState.h
@@ -58,7 +58,7 @@ namespace RE::Scaleform::GFx
 
 	protected:
 		// members
-		REX::EnumSet<StateType, std::int32_t> stateType;
+		REX::Enum<StateType, std::int32_t> stateType;
 	};
 	static_assert(sizeof(State) == 0x18);
 }

--- a/include/RE/S/ScaleformGFxState.h
+++ b/include/RE/S/ScaleformGFxState.h
@@ -58,7 +58,7 @@ namespace RE::Scaleform::GFx
 
 	protected:
 		// members
-		stl::enumeration<StateType, std::int32_t> stateType;
+		REX::EnumSet<StateType, std::int32_t> stateType;
 	};
 	static_assert(sizeof(State) == 0x18);
 }

--- a/include/RE/S/ScaleformGFxValue.h
+++ b/include/RE/S/ScaleformGFxValue.h
@@ -741,12 +741,12 @@ namespace RE::Scaleform::GFx
 		}
 
 		// members
-		Value*                                    _prev{};                         // 00
-		Value*                                    _next{};                         // 08
-		ObjectInterface*                          _objectInterface{};              // 10
-		stl::enumeration<ValueType, std::int32_t> _type{ ValueType::kUndefined };  // 18
-		ValueUnion                                _value{};                        // 20
-		std::size_t                               _dataAux{};                      // 28
+		Value*                                _prev{};                         // 00
+		Value*                                _next{};                         // 08
+		ObjectInterface*                      _objectInterface{};              // 10
+		REX::EnumSet<ValueType, std::int32_t> _type{ ValueType::kUndefined };  // 18
+		ValueUnion                            _value{};                        // 20
+		std::size_t                           _dataAux{};                      // 28
 	};
 	static_assert(sizeof(Value) == 0x30);
 }

--- a/include/RE/S/SpellItem.h
+++ b/include/RE/S/SpellItem.h
@@ -26,13 +26,13 @@ namespace RE
 		{
 		public:
 			// members
-			REX::EnumSet<MagicSystem::SpellType, std::uint8_t>   spellType;     // 08
-			float                                                chargeTime;    // 0C
-			REX::EnumSet<MagicSystem::CastingType, std::uint8_t> castingType;   // 10
-			REX::EnumSet<MagicSystem::Delivery, std::uint8_t>    delivery;      // 11
-			float                                                castDuration;  // 14
-			float                                                range;         // 18
-			BGSPerk*                                             castingPerk;   // 20
+			REX::Enum<MagicSystem::SpellType, std::uint8_t>   spellType;     // 08
+			float                                             chargeTime;    // 0C
+			REX::Enum<MagicSystem::CastingType, std::uint8_t> castingType;   // 10
+			REX::Enum<MagicSystem::Delivery, std::uint8_t>    delivery;      // 11
+			float                                             castDuration;  // 14
+			float                                             range;         // 18
+			BGSPerk*                                          castingPerk;   // 20
 		};
 		static_assert(sizeof(Data) == 0x28);
 

--- a/include/RE/S/SpellItem.h
+++ b/include/RE/S/SpellItem.h
@@ -26,13 +26,13 @@ namespace RE
 		{
 		public:
 			// members
-			stl::enumeration<MagicSystem::SpellType, std::uint8_t>   spellType;     // 08
-			float                                                    chargeTime;    // 0C
-			stl::enumeration<MagicSystem::CastingType, std::uint8_t> castingType;   // 10
-			stl::enumeration<MagicSystem::Delivery, std::uint8_t>    delivery;      // 11
-			float                                                    castDuration;  // 14
-			float                                                    range;         // 18
-			BGSPerk*                                                 castingPerk;   // 20
+			REX::EnumSet<MagicSystem::SpellType, std::uint8_t>   spellType;     // 08
+			float                                                chargeTime;    // 0C
+			REX::EnumSet<MagicSystem::CastingType, std::uint8_t> castingType;   // 10
+			REX::EnumSet<MagicSystem::Delivery, std::uint8_t>    delivery;      // 11
+			float                                                castDuration;  // 14
+			float                                                range;         // 18
+			BGSPerk*                                             castingPerk;   // 20
 		};
 		static_assert(sizeof(Data) == 0x28);
 

--- a/include/RE/S/Stack.h
+++ b/include/RE/S/Stack.h
@@ -28,21 +28,21 @@ namespace RE::BSScript
 		public BSIntrusiveRefCounted  // 00
 	{
 	public:
-		enum class StackType
+		enum class StackType : std::int32_t
 		{
 			kNormal,
 			kPropInit,
 			kInitEvent
 		};
 
-		enum class FreezeState
+		enum class FreezeState : std::int32_t
 		{
 			kUnfrozen,
 			kFreezing,
 			kFrozen
 		};
 
-		enum class State
+		enum class State : std::int32_t
 		{
 			kRunning,
 			kFinished,
@@ -81,24 +81,24 @@ namespace RE::BSScript
 		}
 
 		// members
-		IMemoryPagePolicy*                          policy;         // 08
-		void*                                       unk10;          // 10 -- something to do with guards, guardPolicy maybe?
-		IProfilePolicy*                             profilePolicy;  // 18
-		void*                                       unk20;          // 20
-		/*BSTSmallArray<MemoryPageData, 3>*/ char   pages[0x40];    // 28
-		StackFrame*                                 top;            // 68
-		BSTSmartPointer<Internal::CodeTasklet>      owningTasklet;  // 70
-		BSTSmartPointer<IStackCallbackFunctor>      callback;       // 78
-		BSTSmartPointer<Object>                     objToUnbind;    // 80
-		BSTSmartPointer<Stack>                      nextStack;      // 88
-		Variable                                    returnValue;    // 90
-		std::uint64_t                               unk98;          // A0
-		std::uint64_t                               unkA0;          // A8
-		std::uint32_t                               frames;         // B0
-		std::uint32_t                               stackID;        // B4
-		stl::enumeration<State, std::int32_t>       state;          // B8
-		stl::enumeration<FreezeState, std::int32_t> freezeState;    // BC
-		stl::enumeration<StackType, std::int32_t>   stackType;      // C0
+		IMemoryPagePolicy*                      policy;         // 08
+		void*                                   unk10;          // 10 - something to do with guards, guardPolicy maybe?
+		IProfilePolicy*                         profilePolicy;  // 18
+		void*                                   unk20;          // 20
+		char                                    pages[0x40];    // 28 - BSTSmallArray<MemoryPageData, 3>
+		StackFrame*                             top;            // 68
+		BSTSmartPointer<Internal::CodeTasklet>  owningTasklet;  // 70
+		BSTSmartPointer<IStackCallbackFunctor>  callback;       // 78
+		BSTSmartPointer<Object>                 objToUnbind;    // 80
+		BSTSmartPointer<Stack>                  nextStack;      // 88
+		Variable                                returnValue;    // 90
+		std::uint64_t                           unk98;          // A0
+		std::uint64_t                           unkA0;          // A8
+		std::uint32_t                           frames;         // B0
+		std::uint32_t                           stackID;        // B4
+		State                                   state;          // B8
+		FreezeState                             freezeState;    // BC
+		StackType                               stackType;      // C0
 	};
 	static_assert(sizeof(Stack) == 0xC8);
 }

--- a/include/RE/S/StructTypeInfo.h
+++ b/include/RE/S/StructTypeInfo.h
@@ -23,7 +23,7 @@ namespace RE::BSScript
 		static constexpr auto RTTI{ RTTI::BSScript__StructTypeInfo };
 		static constexpr auto VTABLE{ VTABLE::BSScript__StructTypeInfo };
 
-		enum class LinkValidState
+		enum class LinkValidState : std::int32_t
 		{
 			kNotLinked,
 			kCurrentlyLinking,
@@ -52,11 +52,11 @@ namespace RE::BSScript
 		virtual TypeInfo::RawType GetRawType() const override { return TypeInfo::RawType::kStruct; }  // 01
 
 		// members
-		BSFixedString                                  name;                   // 10
-		BSTSmartPointer<ObjectTypeInfo>                containingObjTypeInfo;  // 18
-		BSTArray<StructVar>                            variables;              // 20
-		BSTHashMap<BSFixedString, std::uint32_t>       varNameIndexMap;        // 30
-		stl::enumeration<LinkValidState, std::int32_t> linkedValid;            // 68
+		BSFixedString                            name;                   // 10
+		BSTSmartPointer<ObjectTypeInfo>          containingObjTypeInfo;  // 18
+		BSTArray<StructVar>                      variables;              // 20
+		BSTHashMap<BSFixedString, std::uint32_t> varNameIndexMap;        // 30
+		LinkValidState                           linkedValid;            // 68
 	};
 	static_assert(sizeof(StructTypeInfo) == 0x70);
 }

--- a/include/RE/T/TESActorBaseData.h
+++ b/include/RE/T/TESActorBaseData.h
@@ -60,14 +60,14 @@ namespace RE
 		};
 
 		// members
-		stl::enumeration<Flag, std::uint32_t>              actorBaseFlags;    // 00
-		std::int16_t                                       xpValueOffset;     // 04
-		std::uint16_t                                      level;             // 06
-		std::uint16_t                                      calcLevelMin;      // 08
-		std::uint16_t                                      calcLevelMax;      // 0A
-		std::uint16_t                                      baseDisposition;   // 0C
-		stl::enumeration<TEMPLATE_USE_FLAG, std::uint16_t> templateUseFlags;  // 0E
-		std::int16_t                                       bleedoutOverride;  // 10
+		REX::EnumSet<Flag, std::uint32_t>              actorBaseFlags;    // 00
+		std::int16_t                                   xpValueOffset;     // 04
+		std::uint16_t                                  level;             // 06
+		std::uint16_t                                  calcLevelMin;      // 08
+		std::uint16_t                                  calcLevelMax;      // 0A
+		std::uint16_t                                  baseDisposition;   // 0C
+		REX::EnumSet<TEMPLATE_USE_FLAG, std::uint16_t> templateUseFlags;  // 0E
+		std::int16_t                                   bleedoutOverride;  // 10
 	};
 	static_assert(sizeof(ACTOR_BASE_DATA) == 0x14);
 

--- a/include/RE/T/TESAmmo.h
+++ b/include/RE/T/TESAmmo.h
@@ -27,10 +27,10 @@ namespace RE
 		};
 
 		// members
-		BGSProjectile*                       projectile;  // 00
-		std::uint32_t                        health;      // 08
-		float                                damage;      // 0C
-		stl::enumeration<Flag, std::uint8_t> flags;       // 10
+		BGSProjectile*                   projectile;  // 00
+		std::uint32_t                    health;      // 08
+		float                            damage;      // 0C
+		REX::EnumSet<Flag, std::uint8_t> flags;       // 10
 	};
 	static_assert(sizeof(AMMO_DATA) == 0x18);
 

--- a/include/RE/T/TESDataHandler.h
+++ b/include/RE/T/TESDataHandler.h
@@ -54,7 +54,7 @@ namespace RE
 		std::uint64_t          unk0058;                                           // 0058
 		std::uint64_t          unk0060;                                           // 0060
 		std::uint64_t          unk0068;                                           // 0068
-		FormArray              formArrays[stl::to_underlying(FormType::kTotal)];  // 0070
+		FormArray              formArrays[std::to_underlying(FormType::kTotal)];  // 0070
 		TESRegionList*         regionList;                                        // 1498
 		std::uint64_t          unk14A0;                                           // 14A0
 		std::uint64_t          unk14A8;                                           // 14A8

--- a/include/RE/T/TESEnchantableForm.h
+++ b/include/RE/T/TESEnchantableForm.h
@@ -22,9 +22,9 @@ namespace RE
 		[[nodiscard]] virtual MagicSystem::CastingType GetCastingType() const;  // 04 - { return castingType; }
 
 		// members
-		EnchantmentItem*                                      formEnchanting;       // 08
-		REX::EnumSet<MagicSystem::CastingType, std::uint16_t> castingType;          // 10
-		std::uint16_t                                         amountofEnchantment;  // 12
+		EnchantmentItem*                                   formEnchanting;       // 08
+		REX::Enum<MagicSystem::CastingType, std::uint16_t> castingType;          // 10
+		std::uint16_t                                      amountofEnchantment;  // 12
 	};
 	static_assert(sizeof(TESEnchantableForm) == 0x18);
 }

--- a/include/RE/T/TESEnchantableForm.h
+++ b/include/RE/T/TESEnchantableForm.h
@@ -22,9 +22,9 @@ namespace RE
 		[[nodiscard]] virtual MagicSystem::CastingType GetCastingType() const;  // 04 - { return castingType; }
 
 		// members
-		EnchantmentItem*                                          formEnchanting;       // 08
-		stl::enumeration<MagicSystem::CastingType, std::uint16_t> castingType;          // 10
-		std::uint16_t                                             amountofEnchantment;  // 12
+		EnchantmentItem*                                      formEnchanting;       // 08
+		REX::EnumSet<MagicSystem::CastingType, std::uint16_t> castingType;          // 10
+		std::uint16_t                                         amountofEnchantment;  // 12
 	};
 	static_assert(sizeof(TESEnchantableForm) == 0x18);
 }

--- a/include/RE/T/TESForm.h
+++ b/include/RE/T/TESForm.h
@@ -245,14 +245,14 @@ namespace RE
 		}
 
 		// members
-		std::uint64_t                            unk18;           // 18
-		std::uint32_t                            formFlags;       // 20
-		std::uint32_t                            unk24;           // 24
-		std::uint32_t                            formID;          // 28
-		std::uint8_t                             formFlags2;      // 2C
-		std::uint8_t                             unk2D;           // 2D
-		stl::enumeration<FormType, std::uint8_t> formType;        // 2E
-		std::uint8_t                             loadOrderIndex;  // 2F - init'd to 0xFF
+		std::uint64_t                        unk18;           // 18
+		std::uint32_t                        formFlags;       // 20
+		std::uint32_t                        unk24;           // 24
+		std::uint32_t                        formID;          // 28
+		std::uint8_t                         formFlags2;      // 2C
+		std::uint8_t                         unk2D;           // 2D
+		REX::EnumSet<FormType, std::uint8_t> formType;        // 2E
+		std::uint8_t                         loadOrderIndex;  // 2F - init'd to 0xFF
 	};
 	static_assert(sizeof(TESForm) == 0x30);
 }

--- a/include/RE/T/TESForm.h
+++ b/include/RE/T/TESForm.h
@@ -245,14 +245,14 @@ namespace RE
 		}
 
 		// members
-		std::uint64_t                        unk18;           // 18
-		std::uint32_t                        formFlags;       // 20
-		std::uint32_t                        unk24;           // 24
-		std::uint32_t                        formID;          // 28
-		std::uint8_t                         formFlags2;      // 2C
-		std::uint8_t                         unk2D;           // 2D
-		REX::EnumSet<FormType, std::uint8_t> formType;        // 2E
-		std::uint8_t                         loadOrderIndex;  // 2F - init'd to 0xFF
+		std::uint64_t                     unk18;           // 18
+		std::uint32_t                     formFlags;       // 20
+		std::uint32_t                     unk24;           // 24
+		std::uint32_t                     formID;          // 28
+		std::uint8_t                      formFlags2;      // 2C
+		std::uint8_t                      unk2D;           // 2D
+		REX::Enum<FormType, std::uint8_t> formType;        // 2E
+		std::uint8_t                      loadOrderIndex;  // 2F - init'd to 0xFF
 	};
 	static_assert(sizeof(TESForm) == 0x30);
 }

--- a/include/RE/T/TESFurniture.h
+++ b/include/RE/T/TESFurniture.h
@@ -9,7 +9,7 @@ namespace RE
 	struct WorkbenchData
 	{
 	public:
-		enum class Type
+		enum class Type : std::uint8_t
 		{
 			kNone = 0,
 			kCreateObject = 1,
@@ -26,7 +26,7 @@ namespace RE
 		};
 
 		// members
-		stl::enumeration<Type, std::uint8_t> type;  // 0
+		Type type;  // 0
 	};
 	static_assert(sizeof(WorkbenchData) == 0x1);
 

--- a/include/RE/T/TESGrass.h
+++ b/include/RE/T/TESGrass.h
@@ -23,20 +23,20 @@ namespace RE
 				kFitSlope = 1 << 2
 			};
 
-			std::uint32_t                        unk00;       // 00
-			float                                unk04;       // 04 - heightRange?
-			float                                unk08;       // 08 - positionRange?
-			float                                wavePeriod;  // 0C
-			std::uint32_t                        unk10;       // 10
-			std::uint32_t                        unk14;       // 14
-			std::uint32_t                        unk18;       // 18
-			std::uint32_t                        unk1C;       // 1C
-			std::uint8_t                         density;     // 20
-			std::uint8_t                         minSlope;    // 21
-			std::uint8_t                         maxSlope;    // 22
-			stl::enumeration<Flag, std::uint8_t> flags;       // 23
-			std::uint8_t                         unk24;       // 24
-			std::uint8_t                         unk25;       // 25
+			std::uint32_t                    unk00;       // 00
+			float                            unk04;       // 04 - heightRange?
+			float                            unk08;       // 08 - positionRange?
+			float                            wavePeriod;  // 0C
+			std::uint32_t                    unk10;       // 10
+			std::uint32_t                    unk14;       // 14
+			std::uint32_t                    unk18;       // 18
+			std::uint32_t                    unk1C;       // 1C
+			std::uint8_t                     density;     // 20
+			std::uint8_t                     minSlope;    // 21
+			std::uint8_t                     maxSlope;    // 22
+			REX::EnumSet<Flag, std::uint8_t> flags;       // 23
+			std::uint8_t                     unk24;       // 24
+			std::uint8_t                     unk25;       // 25
 		};
 		static_assert(sizeof(GRASS_DATA) == 0x28);
 

--- a/include/RE/T/TESLeveledList.h
+++ b/include/RE/T/TESLeveledList.h
@@ -69,7 +69,7 @@ namespace RE
 		LEVELED_OBJECT**                                                               scriptAddedLists;  // 40
 		std::int8_t                                                                    scriptListCount;   // 48
 		std::uint32_t                                                                  unk4C;             // 4C
-		stl::enumeration<Flag, std::uint8_t>                                           flags;             // 50
+		REX::EnumSet<Flag, std::uint8_t>                                               flags;             // 50
 		std::uint8_t                                                                   unk51;             // 51
 		std::uint8_t                                                                   baseListCount;     // 52
 		std::uint8_t                                                                   unk53;             // 53

--- a/include/RE/T/TESNPC.h
+++ b/include/RE/T/TESNPC.h
@@ -104,7 +104,7 @@ namespace RE
 		BSTArray<BGSRelationship*>*                               relationships;    // 430
 		BGSLocalizedString                                        organization;     // 438 - faction?
 		std::uint64_t                                             unk440;           // 440
-		REX::EnumSet<PRONOUN_TYPE, std::uint8_t>                  pronoun;          // 448
+		REX::Enum<PRONOUN_TYPE, std::uint8_t>                     pronoun;          // 448
 	};
 	static_assert(sizeof(TESNPC) == 0x450);
 }

--- a/include/RE/T/TESNPC.h
+++ b/include/RE/T/TESNPC.h
@@ -104,7 +104,7 @@ namespace RE
 		BSTArray<BGSRelationship*>*                               relationships;    // 430
 		BGSLocalizedString                                        organization;     // 438 - faction?
 		std::uint64_t                                             unk440;           // 440
-		stl::enumeration<PRONOUN_TYPE, std::uint8_t>              pronoun;          // 448
+		REX::EnumSet<PRONOUN_TYPE, std::uint8_t>                  pronoun;          // 448
 	};
 	static_assert(sizeof(TESNPC) == 0x450);
 }

--- a/include/RE/T/TESObjectBOOK.h
+++ b/include/RE/T/TESObjectBOOK.h
@@ -42,11 +42,11 @@ namespace RE
 		static_assert(sizeof(Teaches) == 0x8);
 
 		// members
-		stl::enumeration<Flag, std::uint8_t> flags;        // 00
-		Teaches                              teaches;      // 08
-		std::uint32_t                        textOffsetX;  // 10
-		std::uint32_t                        textOffsetY;  // 14
-		std::uint64_t                        unk18;        // 18
+		REX::EnumSet<Flag, std::uint8_t> flags;        // 00
+		Teaches                          teaches;      // 08
+		std::uint32_t                    textOffsetX;  // 10
+		std::uint32_t                    textOffsetY;  // 14
+		std::uint64_t                    unk18;        // 18
 	};
 	static_assert(sizeof(OBJ_BOOK) == 0x20);
 

--- a/include/RE/T/TESObjectCELL.h
+++ b/include/RE/T/TESObjectCELL.h
@@ -88,7 +88,7 @@ namespace RE
 
 		~TESObjectCELL() override;  // 00
 
-		[[nodiscard]] bool IsAttached() const noexcept { return cellState.all(CELL_STATE::kAttached); }
+		[[nodiscard]] bool IsAttached() const noexcept { return cellState == CELL_STATE::kAttached; }
 		[[nodiscard]] bool IsExterior() const noexcept { return !IsInterior(); }
 		[[nodiscard]] bool IsInterior() const noexcept { return cellFlags.any(Flag::kInterior); }
 		[[nodiscard]] bool UsesPlanetGravity() const noexcept { return cellFlags.any(Flag::kUsePlanetGravity); }
@@ -97,49 +97,49 @@ namespace RE
 		void ForEachReferenceInRange(const NiPoint3A& a_origin, float a_radius, std::function<BSContainer::ForEachResult(const NiPointer<TESObjectREFR>&)> a_callback) const;
 
 		// members
-		REX::EnumSet<Flag, std::uint32_t>      cellFlags;       // 040
-		std::uint16_t                          cellGameFlags;   // 044
-		std::uint8_t                           unk04E;          // 046
-		REX::EnumSet<CELL_STATE, std::uint8_t> cellState;       // 047
-		std::uint64_t                          unk050;          // 048
-		BSTSmartPointer<ExtraDataList>         extraDataList;   // 050
-		CellData                               cellData;        // 058
-		std::uint32_t                          unk060;          // 060
-		float                                  unk064;          // 064
-		float                                  unk068;          // 068
-		float                                  unk06C;          // 06C
-		std::uint8_t                           unk070;          // 070
-		std::uint8_t                           pad071;          // 071
-		std::uint16_t                          pad072;          // 072
-		std::uint32_t                          pad074;          // 074
-		std::uint64_t                          unk078;          // 078
-		BSTArray<NiPointer<TESObjectREFR>>     references;      // 080
-		std::uint64_t                          unk090;          // 090
-		std::uint64_t                          unk098;          // 098
-		std::uint64_t                          unk0A0;          // 0A0
-		std::uint64_t                          unk0A8;          // 0A8
-		std::uint64_t                          unk0B0;          // 0B0
-		std::uint64_t                          unk0B8;          // 0B8
-		std::uint64_t                          unk0C0;          // 0C0
-		std::uint64_t                          unk0C8;          // 0C8
-		std::uint64_t                          unk0D0;          // 0D0
-		std::uint64_t                          unk0D8;          // 0D8
-		std::uint64_t                          unk0E0;          // 0E0
-		std::uint8_t                           unk0E8;          // 0E8
-		std::uint8_t                           pad0E9;          // 0E9
-		std::uint16_t                          pad0EA;          // 0EA
-		std::uint32_t                          pad0EC;          // 0EC
-		std::uint64_t                          unk0F0;          // 0F0
-		std::uint64_t                          unk0F8;          // 0F8
-		std::uint64_t                          unk100;          // 100
-		std::uint64_t                          unk108;          // 108
-		std::uint64_t                          unk110;          // 110
-		TESWorldSpace*                         cellWorldspace;  // 118
-		mutable BSReadWriteLock                lock;            // 120
-		std::uint64_t                          unk128;          // 128
-		std::uint64_t                          unk130;          // 130
-		std::uint32_t                          unk138;          // 138
-		std::uint64_t                          unk140;          // 140
+		REX::EnumSet<Flag, std::uint32_t>   cellFlags;       // 040
+		std::uint16_t                       cellGameFlags;   // 044
+		std::uint8_t                        unk04E;          // 046
+		REX::Enum<CELL_STATE, std::uint8_t> cellState;       // 047
+		std::uint64_t                       unk050;          // 048
+		BSTSmartPointer<ExtraDataList>      extraDataList;   // 050
+		CellData                            cellData;        // 058
+		std::uint32_t                       unk060;          // 060
+		float                               unk064;          // 064
+		float                               unk068;          // 068
+		float                               unk06C;          // 06C
+		std::uint8_t                        unk070;          // 070
+		std::uint8_t                        pad071;          // 071
+		std::uint16_t                       pad072;          // 072
+		std::uint32_t                       pad074;          // 074
+		std::uint64_t                       unk078;          // 078
+		BSTArray<NiPointer<TESObjectREFR>>  references;      // 080
+		std::uint64_t                       unk090;          // 090
+		std::uint64_t                       unk098;          // 098
+		std::uint64_t                       unk0A0;          // 0A0
+		std::uint64_t                       unk0A8;          // 0A8
+		std::uint64_t                       unk0B0;          // 0B0
+		std::uint64_t                       unk0B8;          // 0B8
+		std::uint64_t                       unk0C0;          // 0C0
+		std::uint64_t                       unk0C8;          // 0C8
+		std::uint64_t                       unk0D0;          // 0D0
+		std::uint64_t                       unk0D8;          // 0D8
+		std::uint64_t                       unk0E0;          // 0E0
+		std::uint8_t                        unk0E8;          // 0E8
+		std::uint8_t                        pad0E9;          // 0E9
+		std::uint16_t                       pad0EA;          // 0EA
+		std::uint32_t                       pad0EC;          // 0EC
+		std::uint64_t                       unk0F0;          // 0F0
+		std::uint64_t                       unk0F8;          // 0F8
+		std::uint64_t                       unk100;          // 100
+		std::uint64_t                       unk108;          // 108
+		std::uint64_t                       unk110;          // 110
+		TESWorldSpace*                      cellWorldspace;  // 118
+		mutable BSReadWriteLock             lock;            // 120
+		std::uint64_t                       unk128;          // 128
+		std::uint64_t                       unk130;          // 130
+		std::uint32_t                       unk138;          // 138
+		std::uint64_t                       unk140;          // 140
 	};
 	static_assert(sizeof(TESObjectCELL) == 0x148);
 }

--- a/include/RE/T/TESObjectCELL.h
+++ b/include/RE/T/TESObjectCELL.h
@@ -97,49 +97,49 @@ namespace RE
 		void ForEachReferenceInRange(const NiPoint3A& a_origin, float a_radius, std::function<BSContainer::ForEachResult(const NiPointer<TESObjectREFR>&)> a_callback) const;
 
 		// members
-		stl::enumeration<Flag, std::uint32_t>      cellFlags;       // 040
-		std::uint16_t                              cellGameFlags;   // 044
-		std::uint8_t                               unk04E;          // 046
-		stl::enumeration<CELL_STATE, std::uint8_t> cellState;       // 047
-		std::uint64_t                              unk050;          // 048
-		BSTSmartPointer<ExtraDataList>             extraDataList;   // 050
-		CellData                                   cellData;        // 058
-		std::uint32_t                              unk060;          // 060
-		float                                      unk064;          // 064
-		float                                      unk068;          // 068
-		float                                      unk06C;          // 06C
-		std::uint8_t                               unk070;          // 070
-		std::uint8_t                               pad071;          // 071
-		std::uint16_t                              pad072;          // 072
-		std::uint32_t                              pad074;          // 074
-		std::uint64_t                              unk078;          // 078
-		BSTArray<NiPointer<TESObjectREFR>>         references;      // 080
-		std::uint64_t                              unk090;          // 090
-		std::uint64_t                              unk098;          // 098
-		std::uint64_t                              unk0A0;          // 0A0
-		std::uint64_t                              unk0A8;          // 0A8
-		std::uint64_t                              unk0B0;          // 0B0
-		std::uint64_t                              unk0B8;          // 0B8
-		std::uint64_t                              unk0C0;          // 0C0
-		std::uint64_t                              unk0C8;          // 0C8
-		std::uint64_t                              unk0D0;          // 0D0
-		std::uint64_t                              unk0D8;          // 0D8
-		std::uint64_t                              unk0E0;          // 0E0
-		std::uint8_t                               unk0E8;          // 0E8
-		std::uint8_t                               pad0E9;          // 0E9
-		std::uint16_t                              pad0EA;          // 0EA
-		std::uint32_t                              pad0EC;          // 0EC
-		std::uint64_t                              unk0F0;          // 0F0
-		std::uint64_t                              unk0F8;          // 0F8
-		std::uint64_t                              unk100;          // 100
-		std::uint64_t                              unk108;          // 108
-		std::uint64_t                              unk110;          // 110
-		TESWorldSpace*                             cellWorldspace;  // 118
-		mutable BSReadWriteLock                    lock;            // 120
-		std::uint64_t                              unk128;          // 128
-		std::uint64_t                              unk130;          // 130
-		std::uint32_t                              unk138;          // 138
-		std::uint64_t                              unk140;          // 140
+		REX::EnumSet<Flag, std::uint32_t>      cellFlags;       // 040
+		std::uint16_t                          cellGameFlags;   // 044
+		std::uint8_t                           unk04E;          // 046
+		REX::EnumSet<CELL_STATE, std::uint8_t> cellState;       // 047
+		std::uint64_t                          unk050;          // 048
+		BSTSmartPointer<ExtraDataList>         extraDataList;   // 050
+		CellData                               cellData;        // 058
+		std::uint32_t                          unk060;          // 060
+		float                                  unk064;          // 064
+		float                                  unk068;          // 068
+		float                                  unk06C;          // 06C
+		std::uint8_t                           unk070;          // 070
+		std::uint8_t                           pad071;          // 071
+		std::uint16_t                          pad072;          // 072
+		std::uint32_t                          pad074;          // 074
+		std::uint64_t                          unk078;          // 078
+		BSTArray<NiPointer<TESObjectREFR>>     references;      // 080
+		std::uint64_t                          unk090;          // 090
+		std::uint64_t                          unk098;          // 098
+		std::uint64_t                          unk0A0;          // 0A0
+		std::uint64_t                          unk0A8;          // 0A8
+		std::uint64_t                          unk0B0;          // 0B0
+		std::uint64_t                          unk0B8;          // 0B8
+		std::uint64_t                          unk0C0;          // 0C0
+		std::uint64_t                          unk0C8;          // 0C8
+		std::uint64_t                          unk0D0;          // 0D0
+		std::uint64_t                          unk0D8;          // 0D8
+		std::uint64_t                          unk0E0;          // 0E0
+		std::uint8_t                           unk0E8;          // 0E8
+		std::uint8_t                           pad0E9;          // 0E9
+		std::uint16_t                          pad0EA;          // 0EA
+		std::uint32_t                          pad0EC;          // 0EC
+		std::uint64_t                          unk0F0;          // 0F0
+		std::uint64_t                          unk0F8;          // 0F8
+		std::uint64_t                          unk100;          // 100
+		std::uint64_t                          unk108;          // 108
+		std::uint64_t                          unk110;          // 110
+		TESWorldSpace*                         cellWorldspace;  // 118
+		mutable BSReadWriteLock                lock;            // 120
+		std::uint64_t                          unk128;          // 128
+		std::uint64_t                          unk130;          // 130
+		std::uint32_t                          unk138;          // 138
+		std::uint64_t                          unk140;          // 140
 	};
 	static_assert(sizeof(TESObjectCELL) == 0x148);
 }

--- a/include/RE/T/TESObjectCONT.h
+++ b/include/RE/T/TESObjectCONT.h
@@ -28,7 +28,7 @@ namespace RE
 			kShowOwner = 1 << 2
 		};
 
-		stl::enumeration<Flag, std::uint8_t> contFlags;  // 0
+		REX::EnumSet<Flag, std::uint8_t> contFlags;  // 0
 	};
 	static_assert(sizeof(CONT_DATA) == 0x1);
 

--- a/include/RE/T/TESObjectDOOR.h
+++ b/include/RE/T/TESObjectDOOR.h
@@ -47,15 +47,15 @@ namespace RE
 		~TESObjectDOOR() override;  // 00
 
 		// members
-		BGSLocalizedString                   altOpenText;      // 1A8
-		BGSLocalizedString                   altCloseText;     // 1B0
-		BGSAudio::WwiseSoundHook             openSound;        // 1B8
-		BGSAudio::WwiseSoundHook             closeSound;       // 1E8
-		BGSAudio::WwiseSoundHook             lockSound;        // 218
-		std::uint32_t                        unk248;           // 248
-		std::uint32_t                        unk24C;           // 24C
-		stl::enumeration<Flag, std::uint8_t> flags;            // 250
-		BSTArray<TESForm*>                   randomTeleports;  // 258
+		BGSLocalizedString               altOpenText;      // 1A8
+		BGSLocalizedString               altCloseText;     // 1B0
+		BGSAudio::WwiseSoundHook         openSound;        // 1B8
+		BGSAudio::WwiseSoundHook         closeSound;       // 1E8
+		BGSAudio::WwiseSoundHook         lockSound;        // 218
+		std::uint32_t                    unk248;           // 248
+		std::uint32_t                    unk24C;           // 24C
+		REX::EnumSet<Flag, std::uint8_t> flags;            // 250
+		BSTArray<TESForm*>               randomTeleports;  // 258
 	};
 	static_assert(sizeof(TESObjectDOOR) == 0x268);
 }

--- a/include/RE/T/TypeInfo.h
+++ b/include/RE/T/TypeInfo.h
@@ -154,8 +154,8 @@ namespace RE::BSScript
 
 			~D() noexcept { complexTypeInfo = nullptr; }
 
-			stl::enumeration<RawType, std::uintptr_t> rawType;
-			IComplexType*                             complexTypeInfo;
+			REX::EnumSet<RawType, std::uintptr_t> rawType;
+			IComplexType*                         complexTypeInfo;
 		} data;  // 0
 	};
 	static_assert(sizeof(TypeInfo) == 0x8);

--- a/include/RE/V/VirtualMachine.h
+++ b/include/RE/V/VirtualMachine.h
@@ -229,92 +229,92 @@ namespace RE::BSScript
 			//bool StackExists(std::uint32_t stack_id);
 
 			// members
-			ErrorLogger*                                                                      errorLogger;                 // 0060
-			IMemoryPagePolicy*                                                                memoryPagePolicy;            // 0068
-			IObjectHandlePolicy*                                                              handlePolicy;                // 0070
-			ObjectBindPolicy*                                                                 objectBindPolicy;            // 0078
-			IClientVM*                                                                        clientVM;                    // 0080
-			IStackCallbackSaveInterface*                                                      stackCallbackSaveInterface;  // 0088
-			IProfilePolicy*                                                                   profilePolicy;               // 0090
-			IRemoteDebugger*                                                                  remoteDebugger;              // 0098
-			ISavePatcherInterface*                                                            savePatcherInterface;        // 00A0
-			GuardDataIFace                                                                    globalGuardDataInterface;    // 00A8
-			std::uint64_t                                                                     unk01C0;                     // 01C0 -- 2nd param passed into constructor + 0x10
-			mutable BSSpinLock                                                                typeInfoLock;                // 01C8
-			LinkerProcessor                                                                   linker;                      // 01D0
-			/*BSTHashMap<BSFixedString, BSTSmartPointer<ObjectTypeInfo>>*/ std::byte          objectTypeMap[0x38];         // 0258
-			/*BSTHashMap<BSFixedString, BSTSmartPointer<StructTypeInfo>>*/ std::byte          structTypeMap[0x38];         // 0290
-			/*BSTHashMap<std::uint32_t, BSFixedString>*/ std::byte                            typeIDToObjectType[0x38];    // 02C8
-			/*BSTHashMap<BSFixedString, std::uint32_t>*/ std::byte                            objectTypeToTypeID[0x38];    // 0300
-			BSTArray<BSTSmartPointer<ObjectTypeInfo>>                                         typesToUnload;               // 0338
-			std::byte                                                                         gap_0348[0x380 - 0x348];     // 0348
-			/*BSScript::Internal::FunctionMessageProcessor*/ std::byte                        funcMsgProcessor[0x3C0];     // 0380
-			BSTArray<CodeTasklet*>                                                            vmTasks;                     // 0740
-			BSNonReentrantSpinLock                                                            vmTasksLock;                 // 0750
-			std::uint32_t                                                                     gap_754;                     // 0754
-			bool                                                                              overstressed;                // 0758
-			std::byte                                                                         gap0759[0x780 - 0x759];      // 0759
-			/*BSTCommonStaticMessageQueue<BSScript::Internal::SuspendedStack,128>*/ std::byte suspendQueue1[0x1A80];       // 0780
-			/*BSTCommonStaticMessageQueue<BSScript::Internal::SuspendedStack,128>*/ std::byte suspendQueue2[0x1A80];       // 2200
-			BSTArray<SuspendedStack>                                                          overflowSuspendArray1;       // 3C80
-			BSTArray<SuspendedStack>                                                          overflowSuspendArray2;       // 3C90
-			mutable BSSpinLock                                                                suspendQueueLock;            // 3CA0
-			/*BSTCommonStaticMessageQueue<BSScript::Internal::SuspendedStack,128>* */ void*   stacksToResume;              // 3CA8 - ref to suspendQueue1
-			BSTArray<SuspendedStack>*                                                         stacksToResumeOverflow;      // 3CB0 - ref to overflowSuspendArray1
-			/*BSTCommonStaticMessageQueue<BSScript::Internal::SuspendedStack,128>* */ void*   stacksToSuspend;             // 3CB8 - ref to suspendQueue2
-			BSTArray<SuspendedStack>*                                                         stacksToSuspendOverflow;     // 3CC0 - ref to overflowSuspendArray2
-			mutable BSReadWriteLock                                                           runningStacksLock;           // 3CC8
-			/*BSTHashMap<std::uint32_t, BSTSmartPointer<Stack>>*/ std::byte                   allRunningStacks[0x38];      // 3CD0
-			BSTArray<uint32_t>                                                                waitingLatentReturns;        // 3D08
-			std::uint32_t                                                                     nextStackID;                 // 3D18
-			mutable BSSpinLock                                                                frozenStacksLock;            // 3D1C
-			std::uint32_t                                                                     gap3D24;                     // 3D24
-			BSTArray<msvc::unique_ptr<PendingLatentReturn>>                                   pendingLatentReturns;        // 3D28
-			BSTArray<uint32_t>                                                                stacksWaitingOnGuard;        // 3D38
-			BSTSmartPointer<BSScript::Stack>                                                  frozenStacksHead;            // 3D48
-			std::uint32_t                                                                     frozenStacksCount;           // 3D50
-			stl::enumeration<FreezeState, std::uint32_t>                                      freezeState;                 // 3D54
-			mutable BSSpinLock                                                                attachedScriptsLock;         // 3D58
-			/*BSTHashMap<uint64_t, BSTSmallSharedArray<AttachedScript>>*/ std::byte           attachedScripts[0x38];       // 3D60
-			std::uint64_t                                                                     unk3D98;                     // 3D98
-			std::uint32_t                                                                     nextObjectToClean;           // 3DA0
-			std::uint32_t                                                                     gap3DA4;                     // 3DA4
-			std::uint64_t                                                                     nextAttachedObjectToClean;   // 3DA8
-			BSTArray<BSTSmartPointer<Object>>                                                 detachedScripts;             // 3DB0
-			mutable BSSpinLock                                                                structsLock;                 // 3DC0
-			std::uint32_t                                                                     nextStructToClean;           // 3DC8
-			BSTArray<BSTSmartPointer<Struct>>                                                 allStructs;                  // 3DD0
-			mutable BSSpinLock                                                                arraysLock;                  // 3DE0
-			std::uint32_t                                                                     nextArrayToClean;            // 3DE8
-			BSTArray<BSTSmartPointer<Array>>                                                  arrays;                      // 3DF0
-			mutable BSSpinLock                                                                objectResetLock;             // 3E00
-			BSTArray<BSTSmartPointer<Object>>                                                 objectsAwaitingReset;        // 3E08
-			mutable BSSpinLock                                                                loadTableLock;               // 3E18
-			/*BSTHashMap<std::uint64_t, BSTSmartPointer<Object>>*/ std::byte                  loadTable[0x38];             // 3E20
-			/*BSTHashMap<std::uint64_t, std::uint64_t>           */ std::byte                 loadHandlesTable[0x38];      // 3E58
-			/*BSTHashMap<std::uint64_t, BSTSmartPointer<Struct>>*/ std::byte                  structLoadTable[0x38];       // 3E90
-			/*BSTHashMap<std::uint64_t, LoadedArrayEntry>       */ std::byte                  arrayLoadTable[0x38];        // 3EC8
-			std::uint64_t                                                                     unk3F00;                     // 3F00
-			mutable BSSpinLock                                                                queuedUnbindLock;            // 3F08
-			BSTArray<QueuedUnbindRefs>                                                        queuedUnbinds;               // 3F10
-			mutable BSSpinLock                                                                eventRelayLock;              // 3F20
-			/* BSTHashMap<std::uint64_t, BSTSmartPointer<EventRelay>>*/ std::byte             eventRelays[0x38];           // 3F28
-			std::uint64_t                                                                     unk3F60;                     // 3F60
-			std::uint64_t                                                                     unk3F68;                     // 3F68
-			std::uint64_t                                                                     unk3F70;                     // 3F70
-			std::uint64_t                                                                     unk3F78;                     // 3F78
-			std::uint16_t                                                                     currentSaveGameVersion;      // 3F80
-			std::uint16_t                                                                     gap3F82;                     // 3F82
-			std::uint32_t                                                                     saveObjectCount;             // 3F84
-			std::uint32_t                                                                     saveObjectDataCount;         // 3F88
-			std::uint32_t                                                                     saveStructCount;             // 3F8C
-			std::uint32_t                                                                     saveArrayCount;              // 3F90
-			std::uint32_t                                                                     gap3F94;                     // 3F94
-			WritableStringTable                                                               writableStringTable;         // 3F98
-			ReadableStringTable                                                               readableStringTable;         // 3FB0
-			WritableTypeTable                                                                 writableTypeTable;           // 3FC8
-			ReadableTypeTable                                                                 readableTypeTable;           // 3FD8
-			std::byte                                                                         pad3FE0[0x4040 - 0x3FE0];    // 3FE0
+			ErrorLogger*                                    errorLogger;                 // 0060
+			IMemoryPagePolicy*                              memoryPagePolicy;            // 0068
+			IObjectHandlePolicy*                            handlePolicy;                // 0070
+			ObjectBindPolicy*                               objectBindPolicy;            // 0078
+			IClientVM*                                      clientVM;                    // 0080
+			IStackCallbackSaveInterface*                    stackCallbackSaveInterface;  // 0088
+			IProfilePolicy*                                 profilePolicy;               // 0090
+			IRemoteDebugger*                                remoteDebugger;              // 0098
+			ISavePatcherInterface*                          savePatcherInterface;        // 00A0
+			GuardDataIFace                                  globalGuardDataInterface;    // 00A8
+			std::uint64_t                                   unk01C0;                     // 01C0 - 2nd param passed into constructor + 0x10
+			mutable BSSpinLock                              typeInfoLock;                // 01C8
+			LinkerProcessor                                 linker;                      // 01D0
+			std::byte                                       objectTypeMap[0x38];         // 0258 - BSTHashMap<BSFixedString, BSTSmartPointer<ObjectTypeInfo>>
+			std::byte                                       structTypeMap[0x38];         // 0290 - BSTHashMap<BSFixedString, BSTSmartPointer<StructTypeInfo>>
+			std::byte                                       typeIDToObjectType[0x38];    // 02C8 - BSTHashMap<std::uint32_t, BSFixedString>
+			std::byte                                       objectTypeToTypeID[0x38];    // 0300 - BSTHashMap<BSFixedString, std::uint32_t>
+			BSTArray<BSTSmartPointer<ObjectTypeInfo>>       typesToUnload;               // 0338
+			std::byte                                       gap_0348[0x380 - 0x348];     // 0348
+			std::byte                                       funcMsgProcessor[0x3C0];     // 0380 - BSScript::Internal::FunctionMessageProcessor
+			BSTArray<CodeTasklet*>                          vmTasks;                     // 0740
+			BSNonReentrantSpinLock                          vmTasksLock;                 // 0750
+			std::uint32_t                                   gap_754;                     // 0754
+			bool                                            overstressed;                // 0758
+			std::byte                                       gap0759[0x780 - 0x759];      // 0759
+			std::byte                                       suspendQueue1[0x1A80];       // 0780 - BSTCommonStaticMessageQueue<BSScript::Internal::SuspendedStack,128>
+			std::byte                                       suspendQueue2[0x1A80];       // 2200 - BSTCommonStaticMessageQueue<BSScript::Internal::SuspendedStack,128>
+			BSTArray<SuspendedStack>                        overflowSuspendArray1;       // 3C80
+			BSTArray<SuspendedStack>                        overflowSuspendArray2;       // 3C90
+			mutable BSSpinLock                              suspendQueueLock;            // 3CA0
+			void*                                           stacksToResume;              // 3CA8 - ref to suspendQueue1 - BSTCommonStaticMessageQueue<BSScript::Internal::SuspendedStack,128>*
+			BSTArray<SuspendedStack>*                       stacksToResumeOverflow;      // 3CB0 - ref to overflowSuspendArray1
+			void*                                           stacksToSuspend;             // 3CB8 - ref to suspendQueue2 - BSTCommonStaticMessageQueue<BSScript::Internal::SuspendedStack,128>*
+			BSTArray<SuspendedStack>*                       stacksToSuspendOverflow;     // 3CC0 - ref to overflowSuspendArray2
+			mutable BSReadWriteLock                         runningStacksLock;           // 3CC8
+			std::byte                                       allRunningStacks[0x38];      // 3CD0 - BSTHashMap<std::uint32_t, BSTSmartPointer<Stack>>
+			BSTArray<uint32_t>                              waitingLatentReturns;        // 3D08
+			std::uint32_t                                   nextStackID;                 // 3D18
+			mutable BSSpinLock                              frozenStacksLock;            // 3D1C
+			std::uint32_t                                   gap3D24;                     // 3D24
+			BSTArray<msvc::unique_ptr<PendingLatentReturn>> pendingLatentReturns;        // 3D28
+			BSTArray<uint32_t>                              stacksWaitingOnGuard;        // 3D38
+			BSTSmartPointer<BSScript::Stack>                frozenStacksHead;            // 3D48
+			std::uint32_t                                   frozenStacksCount;           // 3D50
+			REX::EnumSet<FreezeState, std::uint32_t>        freezeState;                 // 3D54
+			mutable BSSpinLock                              attachedScriptsLock;         // 3D58
+			std::byte                                       attachedScripts[0x38];       // 3D60 - BSTHashMap<uint64_t, BSTSmallSharedArray<AttachedScript>>
+			std::uint64_t                                   unk3D98;                     // 3D98
+			std::uint32_t                                   nextObjectToClean;           // 3DA0
+			std::uint32_t                                   gap3DA4;                     // 3DA4
+			std::uint64_t                                   nextAttachedObjectToClean;   // 3DA8
+			BSTArray<BSTSmartPointer<Object>>               detachedScripts;             // 3DB0
+			mutable BSSpinLock                              structsLock;                 // 3DC0
+			std::uint32_t                                   nextStructToClean;           // 3DC8
+			BSTArray<BSTSmartPointer<Struct>>               allStructs;                  // 3DD0
+			mutable BSSpinLock                              arraysLock;                  // 3DE0
+			std::uint32_t                                   nextArrayToClean;            // 3DE8
+			BSTArray<BSTSmartPointer<Array>>                arrays;                      // 3DF0
+			mutable BSSpinLock                              objectResetLock;             // 3E00
+			BSTArray<BSTSmartPointer<Object>>               objectsAwaitingReset;        // 3E08
+			mutable BSSpinLock                              loadTableLock;               // 3E18
+			std::byte                                       loadTable[0x38];             // 3E20 - BSTHashMap<std::uint64_t, BSTSmartPointer<Object>>
+			std::byte                                       loadHandlesTable[0x38];      // 3E58 - BSTHashMap<std::uint64_t, std::uint64_t>
+			std::byte                                       structLoadTable[0x38];       // 3E90 - BSTHashMap<std::uint64_t, BSTSmartPointer<Struct>>
+			std::byte                                       arrayLoadTable[0x38];        // 3EC8 - BSTHashMap<std::uint64_t, LoadedArrayEntry>
+			std::uint64_t                                   unk3F00;                     // 3F00
+			mutable BSSpinLock                              queuedUnbindLock;            // 3F08
+			BSTArray<QueuedUnbindRefs>                      queuedUnbinds;               // 3F10
+			mutable BSSpinLock                              eventRelayLock;              // 3F20
+			std::byte                                       eventRelays[0x38];           // 3F28 - BSTHashMap<std::uint64_t, BSTSmartPointer<EventRelay>>
+			std::uint64_t                                   unk3F60;                     // 3F60
+			std::uint64_t                                   unk3F68;                     // 3F68
+			std::uint64_t                                   unk3F70;                     // 3F70
+			std::uint64_t                                   unk3F78;                     // 3F78
+			std::uint16_t                                   currentSaveGameVersion;      // 3F80
+			std::uint16_t                                   gap3F82;                     // 3F82
+			std::uint32_t                                   saveObjectCount;             // 3F84
+			std::uint32_t                                   saveObjectDataCount;         // 3F88
+			std::uint32_t                                   saveStructCount;             // 3F8C
+			std::uint32_t                                   saveArrayCount;              // 3F90
+			std::uint32_t                                   gap3F94;                     // 3F94
+			WritableStringTable                             writableStringTable;         // 3F98
+			ReadableStringTable                             readableStringTable;         // 3FB0
+			WritableTypeTable                               writableTypeTable;           // 3FC8
+			ReadableTypeTable                               readableTypeTable;           // 3FD8
+			std::byte                                       pad3FE0[0x4040 - 0x3FE0];    // 3FE0
 		};
 		static_assert(sizeof(VirtualMachine) == 0x4040);
 		static_assert(offsetof(VirtualMachine, writableStringTable) == 0x3F98);

--- a/include/RE/V/VirtualMachine.h
+++ b/include/RE/V/VirtualMachine.h
@@ -273,7 +273,7 @@ namespace RE::BSScript
 			BSTArray<uint32_t>                              stacksWaitingOnGuard;        // 3D38
 			BSTSmartPointer<BSScript::Stack>                frozenStacksHead;            // 3D48
 			std::uint32_t                                   frozenStacksCount;           // 3D50
-			REX::EnumSet<FreezeState, std::uint32_t>        freezeState;                 // 3D54
+			REX::Enum<FreezeState, std::uint32_t>           freezeState;                 // 3D54
 			mutable BSSpinLock                              attachedScriptsLock;         // 3D58
 			std::byte                                       attachedScripts[0x38];       // 3D60 - BSTHashMap<uint64_t, BSTSmallSharedArray<AttachedScript>>
 			std::uint64_t                                   unk3D98;                     // 3D98

--- a/include/RE/W/WritableStringTable.h
+++ b/include/RE/W/WritableStringTable.h
@@ -13,7 +13,7 @@ namespace RE::BSScript::Internal
 		// members
 		msvc::unique_ptr<BSTObjectArena<BSFixedString>> stringTable;         // 00
 		void*                                           stringReferenceMap;  // 08 - msvc::unique_ptr<BSTScrapHashMap<BSFixedString, std::uint32_t>>
-		REX::EnumSet<StringIndexSize, std::int32_t>     indexSize;           // 10
+		REX::Enum<StringIndexSize, std::int32_t>        indexSize;           // 10
 	};
 	static_assert(sizeof(WritableStringTable) == 0x18);
 }

--- a/include/RE/W/WritableStringTable.h
+++ b/include/RE/W/WritableStringTable.h
@@ -11,9 +11,9 @@ namespace RE::BSScript::Internal
 	{
 	public:
 		// members
-		msvc::unique_ptr<BSTObjectArena<BSFixedString>>                           stringTable;         // 00
-		/*msvc::unique_ptr<BSTScrapHashMap<BSFixedString, std::uint32_t>>*/ void* stringReferenceMap;  // 08
-		stl::enumeration<StringIndexSize, std::int32_t>                           indexSize;           // 10
+		msvc::unique_ptr<BSTObjectArena<BSFixedString>> stringTable;         // 00
+		void*                                           stringReferenceMap;  // 08 - msvc::unique_ptr<BSTScrapHashMap<BSFixedString, std::uint32_t>>
+		REX::EnumSet<StringIndexSize, std::int32_t>     indexSize;           // 10
 	};
 	static_assert(sizeof(WritableStringTable) == 0x18);
 }

--- a/include/REX/REX.h
+++ b/include/REX/REX.h
@@ -5,6 +5,73 @@ namespace REX
 	template <
 		class E,
 		class U = std::underlying_type_t<E>>
+	class Enum
+	{
+	public:
+		using enum_type = E;
+		using underlying_type = U;
+
+		static_assert(std::is_enum_v<E>, "Enum<E, ...> must be an enum");
+		static_assert(std::is_integral_v<U>, "Enum<..., U> must be an integral");
+
+		constexpr Enum() noexcept = default;
+		constexpr Enum(const Enum&) noexcept = default;
+		constexpr Enum(Enum&&) noexcept = default;
+
+		template <class U2>  // NOLINTNEXTLINE(google-explicit-constructor)
+		constexpr Enum(Enum<E, U2> a_rhs) noexcept :
+			_impl(static_cast<U>(a_rhs.get()))
+		{}
+
+		constexpr Enum(E a_value) noexcept :
+			_impl(static_cast<U>(a_value))
+		{}
+
+		~Enum() noexcept = default;
+
+		constexpr Enum& operator=(const Enum&) noexcept = default;
+		constexpr Enum& operator=(Enum&&) noexcept = default;
+
+		template <class U2>
+		constexpr Enum& operator=(Enum<E, U2> a_rhs) noexcept
+		{
+			_impl = static_cast<U>(a_rhs.get());
+		}
+
+		constexpr Enum& operator=(E a_value) noexcept
+		{
+			_impl = static_cast<U>(a_value);
+			return *this;
+		}
+
+	public:
+		[[nodiscard]] explicit constexpr operator bool() const noexcept { return _impl != static_cast<U>(0); }
+
+		[[nodiscard]] constexpr E operator*() const noexcept { return get(); }
+		[[nodiscard]] constexpr E get() const noexcept { return static_cast<E>(_impl); }
+		[[nodiscard]] constexpr U underlying() const noexcept { return _impl; }
+
+	public:
+		friend constexpr bool operator==(Enum a_lhs, Enum a_rhs) noexcept { return a_lhs.underlying() == a_rhs.underlying(); }
+		friend constexpr bool operator==(Enum a_lhs, E a_rhs) noexcept { return a_lhs.underlying() == static_cast<U>(a_rhs); }
+		friend constexpr bool operator==(E a_lhs, Enum a_rhs) noexcept { return static_cast<U>(a_lhs) == a_rhs.underlying(); }
+
+	private:
+		U _impl{ 0 };
+	};
+
+	template <class... Args>
+	Enum(Args...) -> Enum<
+		std::common_type_t<Args...>,
+		std::underlying_type_t<
+			std::common_type_t<Args...>>>;
+}
+
+namespace REX
+{
+	template <
+		class E,
+		class U = std::underlying_type_t<E>>
 	class EnumSet
 	{
 	public:

--- a/include/REX/W32/D3D.h
+++ b/include/REX/W32/D3D.h
@@ -695,7 +695,6 @@ namespace REX::W32
 
 	struct XMCOLOR
 	{
-	public:
 		union
 		{
 			struct
@@ -712,7 +711,6 @@ namespace REX::W32
 
 	struct XMFLOAT3
 	{
-	public:
 		float x;
 		float y;
 		float z;
@@ -721,7 +719,6 @@ namespace REX::W32
 
 	struct XMFLOAT4
 	{
-	public:
 		float x;
 		float y;
 		float z;

--- a/include/SFSE/Impl/PCH.h
+++ b/include/SFSE/Impl/PCH.h
@@ -481,13 +481,6 @@ namespace SFSE::stl
 		std::unreachable();
 	}
 
-	template <class Enum>
-	[[nodiscard]] constexpr auto to_underlying(Enum a_val) noexcept
-		requires(std::is_enum_v<Enum>)
-	{
-		return static_cast<std::underlying_type_t<Enum>>(a_val);
-	}
-
 	template <class To, class From>
 	[[nodiscard]] To unrestricted_cast(From a_from) noexcept
 	{

--- a/include/SFSE/Impl/PCH.h
+++ b/include/SFSE/Impl/PCH.h
@@ -264,210 +264,33 @@ namespace SFSE
 		template <class EF>
 		scope_exit(EF) -> scope_exit<EF>;
 
-		template <class Enum, class Underlying = std::underlying_type_t<Enum>>
-		class enumeration
+		// backwards compat
+		template <
+			class E,
+			class U = std::underlying_type_t<E>>
+		class enumeration : public REX::EnumSet<E, U>
 		{
+			using super = REX::EnumSet<E, U>;
+
 		public:
-			using enum_type = Enum;
-			using underlying_type = Underlying;
+			using enum_type = E;
+			using underlying_type = U;
 
-			static_assert(std::is_enum_v<enum_type>, "enum_type must be an enum");
-			static_assert(std::is_integral_v<underlying_type>, "underlying_type must be an integral");
-
-			constexpr enumeration() noexcept = default;
-
-			constexpr enumeration(const enumeration&) noexcept = default;
-
-			constexpr enumeration(enumeration&&) noexcept = default;
-
-			template <class U2>  // NOLINTNEXTLINE(google-explicit-constructor)
-			constexpr enumeration(enumeration<Enum, U2> a_rhs) noexcept :
-				_impl(static_cast<underlying_type>(a_rhs.get()))
-			{}
-
-			template <class... Args>
-			constexpr enumeration(Args... a_values) noexcept
-				requires(std::same_as<Args, enum_type> && ...)
-				:
-				_impl((static_cast<underlying_type>(a_values) | ...))
-			{}
-
-			~enumeration() noexcept = default;
-
-			constexpr enumeration& operator=(const enumeration&) noexcept = default;
-			constexpr enumeration& operator=(enumeration&&) noexcept = default;
-
-			template <class U2>
-			constexpr enumeration& operator=(enumeration<Enum, U2> a_rhs) noexcept
-			{
-				_impl = static_cast<underlying_type>(a_rhs.get());
-				return *this;
-			}
-
-			constexpr enumeration& operator=(enum_type a_value) noexcept
-			{
-				_impl = static_cast<underlying_type>(a_value);
-				return *this;
-			}
-
-			[[nodiscard]] explicit constexpr operator bool() const noexcept { return _impl != static_cast<underlying_type>(0); }
-
-			[[nodiscard]] constexpr enum_type operator*() const noexcept { return get(); }
-
-			[[nodiscard]] constexpr enum_type get() const noexcept { return static_cast<enum_type>(_impl); }
-
-			[[nodiscard]] constexpr underlying_type underlying() const noexcept { return _impl; }
-
-			template <class... Args>
-			constexpr enumeration& set(Args... a_args) noexcept
-				requires(std::same_as<Args, enum_type> && ...)
-			{
-				_impl |= (static_cast<underlying_type>(a_args) | ...);
-				return *this;
-			}
-
-			template <class... Args>
-			constexpr enumeration& reset(Args... a_args) noexcept
-				requires(std::same_as<Args, enum_type> && ...)
-			{
-				_impl &= ~(static_cast<underlying_type>(a_args) | ...);
-				return *this;
-			}
-
-			template <class... Args>
-			[[nodiscard]] constexpr bool any(Args... a_args) const noexcept
-				requires(std::same_as<Args, enum_type> && ...)
-			{
-				return (_impl & (static_cast<underlying_type>(a_args) | ...)) != static_cast<underlying_type>(0);
-			}
-
-			template <class... Args>
-			[[nodiscard]] constexpr bool all(Args... a_args) const noexcept
-				requires(std::same_as<Args, enum_type> && ...)
-			{
-				return (_impl & (static_cast<underlying_type>(a_args) | ...)) == (static_cast<underlying_type>(a_args) | ...);
-			}
-
-			template <class... Args>
-			[[nodiscard]] constexpr bool none(Args... a_args) const noexcept
-				requires(std::same_as<Args, enum_type> && ...)
-			{
-				return (_impl & (static_cast<underlying_type>(a_args) | ...)) == static_cast<underlying_type>(0);
-			}
-
-		private:
-			underlying_type _impl{};
+			using super::super;
+			using super::operator=;
+			using super::operator*;
 		};
 
 		template <class... Args>
-		enumeration(Args...) -> enumeration<std::common_type_t<Args...>>;
+		enumeration(Args...) -> enumeration<
+			std::common_type_t<Args...>,
+			std::underlying_type_t<
+				std::common_type_t<Args...>>>;
 	}
 }
 
-#define SFSE_MAKE_LOGICAL_OP(a_op, a_result)                                                                    \
-	template <class E, class U1, class U2>                                                                      \
-	[[nodiscard]] constexpr a_result operator a_op(enumeration<E, U1> a_lhs, enumeration<E, U2> a_rhs) noexcept \
-	{                                                                                                           \
-		return a_lhs.get() a_op a_rhs.get();                                                                    \
-	}                                                                                                           \
-                                                                                                                \
-	template <class E, class U>                                                                                 \
-	[[nodiscard]] constexpr a_result operator a_op(enumeration<E, U> a_lhs, E a_rhs) noexcept                   \
-	{                                                                                                           \
-		return a_lhs.get() a_op a_rhs;                                                                          \
-	}
-
-#define SFSE_MAKE_ARITHMETIC_OP(a_op)                                                                             \
-	template <class E, class U>                                                                                   \
-	[[nodiscard]] constexpr auto operator a_op(enumeration<E, U> a_enum, U a_shift) noexcept -> enumeration<E, U> \
-	{                                                                                                             \
-		return static_cast<E>(static_cast<U>(a_enum.get()) a_op a_shift);                                         \
-	}                                                                                                             \
-                                                                                                                  \
-	template <class E, class U>                                                                                   \
-	constexpr auto operator a_op##=(enumeration<E, U>& a_enum, U a_shift) noexcept -> enumeration<E, U>&          \
-	{                                                                                                             \
-		return a_enum = a_enum a_op a_shift;                                                                      \
-	}
-
-#define SFSE_MAKE_ENUMERATION_OP(a_op)                                                                                                                    \
-	template <class E, class U1, class U2>                                                                                                                \
-	[[nodiscard]] constexpr auto operator a_op(enumeration<E, U1> a_lhs, enumeration<E, U2> a_rhs) noexcept -> enumeration<E, std::common_type_t<U1, U2>> \
-	{                                                                                                                                                     \
-		return static_cast<E>(static_cast<U1>(a_lhs.get()) a_op static_cast<U2>(a_rhs.get()));                                                            \
-	}                                                                                                                                                     \
-                                                                                                                                                          \
-	template <class E, class U>                                                                                                                           \
-	[[nodiscard]] constexpr auto operator a_op(enumeration<E, U> a_lhs, E a_rhs) noexcept -> enumeration<E, U>                                            \
-	{                                                                                                                                                     \
-		return static_cast<E>(static_cast<U>(a_lhs.get()) a_op static_cast<U>(a_rhs));                                                                    \
-	}                                                                                                                                                     \
-                                                                                                                                                          \
-	template <class E, class U>                                                                                                                           \
-	[[nodiscard]] constexpr auto operator a_op(E a_lhs, enumeration<E, U> a_rhs) noexcept -> enumeration<E, U>                                            \
-	{                                                                                                                                                     \
-		return static_cast<E>(static_cast<U>(a_lhs) a_op static_cast<U>(a_rhs.get()));                                                                    \
-	}                                                                                                                                                     \
-                                                                                                                                                          \
-	template <class E, class U1, class U2>                                                                                                                \
-	constexpr auto operator a_op##=(enumeration<E, U1>& a_lhs, enumeration<E, U2> a_rhs) noexcept -> enumeration<E, U1>&                                  \
-	{                                                                                                                                                     \
-		return a_lhs = a_lhs a_op a_rhs;                                                                                                                  \
-	}                                                                                                                                                     \
-                                                                                                                                                          \
-	template <class E, class U>                                                                                                                           \
-	constexpr auto operator a_op##=(enumeration<E, U>& a_lhs, E a_rhs) noexcept -> enumeration<E, U>&                                                     \
-	{                                                                                                                                                     \
-		return a_lhs = a_lhs a_op a_rhs;                                                                                                                  \
-	}                                                                                                                                                     \
-                                                                                                                                                          \
-	template <class E, class U>                                                                                                                           \
-	constexpr auto operator a_op##=(E& a_lhs, enumeration<E, U> a_rhs) noexcept -> E&                                                                     \
-	{                                                                                                                                                     \
-		return a_lhs = *(a_lhs a_op a_rhs);                                                                                                               \
-	}
-
-#define SFSE_MAKE_INCREMENTER_OP(a_op)                                                                            \
-	template <class E, class U>                                                                                   \
-	constexpr auto operator a_op##a_op(enumeration<E, U>& a_lhs) noexcept -> enumeration<E, U>&                   \
-	{                                                                                                             \
-		return a_lhs a_op## = static_cast<E>(1);                                                                  \
-	}                                                                                                             \
-                                                                                                                  \
-	template <class E, class U>                                                                                   \
-	[[nodiscard]] constexpr auto operator a_op##a_op(enumeration<E, U>& a_lhs, int) noexcept -> enumeration<E, U> \
-	{                                                                                                             \
-		const auto tmp = a_lhs;                                                                                   \
-		a_op##a_op a_lhs;                                                                                         \
-		return tmp;                                                                                               \
-	}
-
 namespace SFSE::stl
 {
-	template <class E, class U>
-	[[nodiscard]] constexpr auto operator~(enumeration<E, U> a_enum) noexcept -> enumeration<E, U>
-	{
-		return static_cast<E>(~static_cast<U>(a_enum.get()));
-	}
-
-	SFSE_MAKE_LOGICAL_OP(==, bool);
-	SFSE_MAKE_LOGICAL_OP(<=>, std::strong_ordering);
-
-	SFSE_MAKE_ARITHMETIC_OP(<<);
-	SFSE_MAKE_ENUMERATION_OP(<<);
-	SFSE_MAKE_ARITHMETIC_OP(>>);
-	SFSE_MAKE_ENUMERATION_OP(>>);
-
-	SFSE_MAKE_ENUMERATION_OP(|);
-	SFSE_MAKE_ENUMERATION_OP(&);
-	SFSE_MAKE_ENUMERATION_OP(^);
-
-	SFSE_MAKE_ENUMERATION_OP(+);
-	SFSE_MAKE_ENUMERATION_OP(-);
-
-	SFSE_MAKE_INCREMENTER_OP(+);  // ++
-	SFSE_MAKE_INCREMENTER_OP(-);  // --
-
 	template <class T>
 	class atomic_ref : public std::atomic_ref<T>
 	{
@@ -696,11 +519,6 @@ namespace SFSE::stl
 		}
 	}
 }
-
-#undef SFSE_MAKE_INCREMENTER_OP
-#undef SFSE_MAKE_ENUMERATION_OP
-#undef SFSE_MAKE_ARITHMETIC_OP
-#undef SFSE_MAKE_LOGICAL_OP
 
 namespace RE
 {

--- a/include/SFSE/Impl/PCH.h
+++ b/include/SFSE/Impl/PCH.h
@@ -205,65 +205,6 @@ namespace SFSE
 			string(const CharT (&)[N]) -> string<CharT, N - 1>;
 		}
 
-		template <class EF>
-			requires(std::invocable<std::remove_reference_t<EF>>)
-		class scope_exit
-		{
-		public:
-			// 1)
-			template <class Fn>
-			explicit scope_exit(Fn&& a_fn)  //
-				noexcept(std::is_nothrow_constructible_v<EF, Fn> || std::is_nothrow_constructible_v<EF, Fn&>)
-				requires(!std::is_same_v<std::remove_cvref_t<Fn>, scope_exit> && std::is_constructible_v<EF, Fn>)
-			{
-				static_assert(std::invocable<Fn>);
-
-				if constexpr (!std::is_lvalue_reference_v<Fn> && std::is_nothrow_constructible_v<EF, Fn>) {
-					_fn.emplace(std::forward<Fn>(a_fn));
-				} else {
-					_fn.emplace(a_fn);
-				}
-			}
-
-			// 2)
-			scope_exit(scope_exit&& a_rhs)  //
-				noexcept(std::is_nothrow_move_constructible_v<EF> || std::is_nothrow_copy_constructible_v<EF>)
-				requires(std::is_nothrow_move_constructible_v<EF> || std::is_copy_constructible_v<EF>)
-			{
-				static_assert(!(std::is_nothrow_move_constructible_v<EF> && !std::is_move_constructible_v<EF>));
-				static_assert(!(!std::is_nothrow_move_constructible_v<EF> && !std::is_copy_constructible_v<EF>));
-
-				if (a_rhs.active()) {
-					if constexpr (std::is_nothrow_move_constructible_v<EF>) {
-						_fn.emplace(std::forward<EF>(*a_rhs._fn));
-					} else {
-						_fn.emplace(a_rhs._fn);
-					}
-					a_rhs.release();
-				}
-			}
-
-			// 3)
-			scope_exit(const scope_exit&) = delete;
-
-			~scope_exit() noexcept
-			{
-				if (_fn.has_value()) {
-					(*_fn)();
-				}
-			}
-
-			void release() noexcept { _fn.reset(); }
-
-		private:
-			[[nodiscard]] bool active() const noexcept { return _fn.has_value(); }
-
-			std::optional<std::remove_reference_t<EF>> _fn;
-		};
-
-		template <class EF>
-		scope_exit(EF) -> scope_exit<EF>;
-
 		// backwards compat
 		template <
 			class E,

--- a/src/RE/A/Array.cpp
+++ b/src/RE/A/Array.cpp
@@ -177,7 +177,7 @@ namespace RE::BSScript
 
 	[[nodiscard]] TypeInfo::RawType Array::type() const
 	{
-		const stl::enumeration typeID = elementType.GetRawType();
+		const REX::EnumSet typeID = elementType.GetRawType();
 		switch (*typeID) {
 		case TypeInfo::RawType::kNone:
 		case TypeInfo::RawType::kObject:

--- a/src/RE/F/FormTypes.cpp
+++ b/src/RE/F/FormTypes.cpp
@@ -6,7 +6,7 @@ namespace RE
 {
 	const char* FormTypeToString(FormType a_formType)
 	{
-		return FORM_ENUM_STRING::GetFormEnumString()[stl::to_underlying(a_formType)].formString;
+		return FORM_ENUM_STRING::GetFormEnumString()[std::to_underlying(a_formType)].formString;
 	}
 
 	FormType StringToFormType(std::string_view a_formType)


### PR DESCRIPTION
- added a `REX::Enum<T>` to address the situation where an enum member variable has a different underlying type than the enum type itself. It should be a cut down version of `EnumSet` as they aren't flags.
  - for example: `FormType` internally is a int32_t, but is often used as either an uint8_t, uint32_t, or even uint64_t in some classes.