### PR TITLE
feat: xmake | support plugin installation and packaging

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -33,6 +33,9 @@ target("commonlibsf")
     -- set target kind
     set_kind("static")
 
+    -- set build by default
+    set_default(os.scriptdir() == os.projectdir())
+
     -- add packages
     add_packages("spdlog", { public = true })
 


### PR DESCRIPTION
- when you build (or run `xmake install`) it will search for the environment variable `XSE_SF_MODS_PATH` or `XSE_SF_GAME_PATH` and copy install files (by default ".dll" and ".pdb") to the paths listed. More files can be added using `add_installfiles`.
- when you run `xmake package` it will package the same files from above into a zip archive named after the target and the version.
- these events can be overwritten if you wish to make your own install/package logic.